### PR TITLE
Create BullaInvoice contract, move stuff around

### DIFF
--- a/src/BullaClaim.sol
+++ b/src/BullaClaim.sol
@@ -267,7 +267,6 @@ contract BullaClaim is ERC721, EIP712, Ownable, BoringBatchable {
             params.creditor,
             params.debtor,
             params.claimAmount,
-            params.dueBy,
             params.description,
             params.token,
             params.controller,
@@ -640,7 +639,6 @@ contract BullaClaim is ERC721, EIP712, Ownable, BoringBatchable {
             binding: claimStorage.binding,
             payerReceivesClaimOnPayment: claimStorage.payerReceivesClaimOnPayment,
             debtor: claimStorage.debtor,
-            dueBy: uint256(claimStorage.dueBy),
             token: claimStorage.token,
             controller: claimStorage.controller
         });

--- a/src/BullaClaim.sol
+++ b/src/BullaClaim.sol
@@ -48,7 +48,6 @@ contract BullaClaim is ERC721, EIP712, Ownable, BoringBatchable {
     error CannotBindClaim();
     error InvalidApproval();
     error InvalidSignature();
-    error InvalidTimestamp();
     error PastApprovalDeadline();
     error NotOwner();
     error NotCreditorOrDebtor();
@@ -77,7 +76,6 @@ contract BullaClaim is ERC721, EIP712, Ownable, BoringBatchable {
         address indexed creditor,
         address indexed debtor,
         uint256 claimAmount,
-        uint256 dueBy,
         string description,
         address token,
         address controller,
@@ -241,11 +239,7 @@ contract BullaClaim is ERC721, EIP712, Ownable, BoringBatchable {
         if (lockState != LockState.Unlocked) revert Locked();
         if (params.controller != address(0) && params.controller != msg.sender) revert NotController(msg.sender);
         if (from != params.debtor && from != params.creditor) revert NotCreditorOrDebtor();
-        // we allow dueBy to be 0 in the case of an "open" claim, or we allow a reasonable timestamp
-        if (params.dueBy != 0 && (params.dueBy < block.timestamp && params.dueBy < type(uint40).max)) {
-            //todo fix
-            revert InvalidTimestamp();
-        }
+
         // you need the permission of the debtor to bind a claim
         if (params.binding == ClaimBinding.Bound && from != params.debtor) revert CannotBindClaim();
         if (params.claimAmount == 0) revert ZeroAmount();
@@ -261,7 +255,6 @@ contract BullaClaim is ERC721, EIP712, Ownable, BoringBatchable {
             claim.claimAmount = params.claimAmount.safeCastTo128(); //TODO: is this necessary?
             claim.debtor = params.debtor;
 
-            if (params.dueBy != 0) claim.dueBy = uint40(params.dueBy);
             if (params.token != address(0)) claim.token = params.token;
             if (params.controller != address(0)) claim.controller = params.controller;
             if (params.binding != ClaimBinding.Unbound) claim.binding = params.binding;

--- a/src/BullaClaimControllerBase.sol
+++ b/src/BullaClaimControllerBase.sol
@@ -5,7 +5,7 @@ import "contracts/interfaces/IBullaClaim.sol";
 import "contracts/types/Types.sol";
 
 abstract contract BullaClaimControllerBase {
-    IBullaClaim internal immutable _bullaClaim;
+    IBullaClaim public immutable _bullaClaim;
 
     constructor(address bullaClaimAddress) {
         _bullaClaim = IBullaClaim(bullaClaimAddress);

--- a/src/BullaClaimControllerBase.sol
+++ b/src/BullaClaimControllerBase.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.15;
+
+import "contracts/interfaces/IBullaClaim.sol";
+import "contracts/types/Types.sol";
+
+abstract contract BullaClaimControllerBase {
+    IBullaClaim internal immutable _bullaClaim;
+
+    constructor(address bullaClaimAddress) {
+        _bullaClaim = BullaClaim(bullaClaimAddress);
+    }
+
+    function _checkController(address controller) internal view {
+        if (controller != address(this)) {
+            revert BullaClaim.NotController(controller);
+        }
+    }
+}

--- a/src/BullaClaimControllerBase.sol
+++ b/src/BullaClaimControllerBase.sol
@@ -8,12 +8,12 @@ abstract contract BullaClaimControllerBase {
     IBullaClaim internal immutable _bullaClaim;
 
     constructor(address bullaClaimAddress) {
-        _bullaClaim = BullaClaim(bullaClaimAddress);
+        _bullaClaim = IBullaClaim(bullaClaimAddress);
     }
 
     function _checkController(address controller) internal view {
         if (controller != address(this)) {
-            revert BullaClaim.NotController(controller);
+            revert IBullaClaim.NotController(controller);
         }
     }
 }

--- a/src/BullaInvoice.sol
+++ b/src/BullaInvoice.sol
@@ -30,7 +30,6 @@ struct CreateInvoiceParams {
     uint256 dueBy;
     string description;
     address token;
-    address controller;
     ClaimBinding binding;
     bool payerReceivesClaimOnPayment;
 }
@@ -89,6 +88,7 @@ contract BullaInvoice is BullaClaimControllerBase {
             payerReceivesClaimOnPayment: params.payerReceivesClaimOnPayment
         });
 
+        // TODO: emit InvoiceCreated event to index dueBy
         return _bullaClaim.createClaimFrom(msg.sender, createClaimParams);
     }
 
@@ -114,6 +114,8 @@ contract BullaInvoice is BullaClaimControllerBase {
             payerReceivesClaimOnPayment: params.payerReceivesClaimOnPayment
         });
 
+        // TODO: emit InvoiceCreated event to index dueBy
+
         return _bullaClaim.createClaimWithMetadataFrom(msg.sender, createClaimParams, metadata);
     }
 
@@ -122,7 +124,7 @@ contract BullaInvoice is BullaClaimControllerBase {
      * @param claimId The ID of the invoice to pay
      * @param amount The amount to pay
      */
-    function payClaim(uint256 claimId, uint256 amount) external payable {
+    function payInvoice(uint256 claimId, uint256 amount) external payable {
         Claim memory claim = _bullaClaim.getClaim(claimId);
         _checkController(claim.controller);
 
@@ -146,7 +148,7 @@ contract BullaInvoice is BullaClaimControllerBase {
      * @param claimId The ID of the invoice to cancel
      * @param note The note to cancel the invoice with
      */
-    function cancelClaim(uint256 claimId, string memory note) external {
+    function cancelInvoice(uint256 claimId, string memory note) external {
         Claim memory claim = _bullaClaim.getClaim(claimId);
         _checkController(claim.controller);
 

--- a/src/BullaInvoice.sol
+++ b/src/BullaInvoice.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.15;
 
 import "contracts/interfaces/IBullaClaim.sol";
+import "contracts/BullaClaimControllerBase.sol";
 import "contracts/types/Types.sol";
 
 // Data specific to invoices and not claims
@@ -84,7 +85,6 @@ contract BullaInvoice is BullaClaimControllerBase {
             claimAmount: params.claimAmount,
             description: params.description,
             token: params.token,
-            controller: params.controller,
             binding: params.binding,
             payerReceivesClaimOnPayment: params.payerReceivesClaimOnPayment
         });
@@ -110,7 +110,6 @@ contract BullaInvoice is BullaClaimControllerBase {
             claimAmount: params.claimAmount,
             description: params.description,
             token: params.token,
-            controller: params.controller,
             binding: params.binding,
             payerReceivesClaimOnPayment: params.payerReceivesClaimOnPayment
         });
@@ -135,7 +134,7 @@ contract BullaInvoice is BullaClaimControllerBase {
      * @param claimId The ID of the invoice to update
      * @param binding The new binding for the invoice
      */
-    function updateBinding(uint256 claimId, uint8 binding) external {
+    function updateBinding(uint256 claimId, ClaimBinding binding) external {
         Claim memory claim = _bullaClaim.getClaim(claimId);
         _checkController(claim.controller);
 

--- a/src/BullaInvoice.sol
+++ b/src/BullaInvoice.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.15;
+
+import "contracts/interfaces/IBullaClaim.sol";
+import "contracts/types/Types.sol";
+
+/**
+ * @title BullaInvoice
+ * @notice A wrapper contract for IBullaClaim that delegates all calls to the provided contract instance
+ */
+contract BullaInvoice {
+    IBullaClaim private immutable _bullaClaim;
+
+    // Data specific to invoices and not claims
+    struct InvoiceDetails {
+        uint16 interestRateBps; // for late payment
+    }
+
+    error InvoiceDoesNotExist(uint256 claimId);
+
+    struct Invoice {
+        uint256 claimAmount;
+        uint256 paidAmount;
+        Status status;
+        ClaimBinding binding;
+        bool payerReceivesClaimOnPayment;
+        address debtor;
+        uint256 dueBy;
+        address token;
+        InvoiceDetails details;
+    }
+
+    mapping(uint256 => InvoiceDetails) private invoiceDetailsByClaimId;
+
+    // Track all claim IDs created through this contract
+    uint256[] private _createdClaimIds;
+    mapping(uint256 => bool) private _isClaimCreatedHere;
+
+    /**
+     * @notice Constructor
+     * @param bullaClaim Address of the IBullaClaim contract to delegate calls to
+     */
+    constructor(address bullaClaim) {
+        _bullaClaim = IBullaClaim(bullaClaim);
+    }
+
+    function getInvoice(uint256 claimId) external view returns (Invoice memory) {
+        if (_isClaimCreatedHere[claimId]) {
+            Claim memory claim = _bullaClaim.getClaim(claimId);
+            return Invoice({
+                claimAmount: claim.claimAmount,
+                paidAmount: claim.paidAmount,
+                status: claim.status,
+                binding: claim.binding,
+                payerReceivesClaimOnPayment: claim.payerReceivesClaimOnPayment,
+                debtor: claim.debtor,
+                dueBy: claim.dueBy,
+                token: claim.token,
+                details: invoiceDetailsByClaimId[claimId]
+            });
+        }
+
+        revert InvoiceDoesNotExist(claimId);
+    }
+
+    function createClaim(CreateClaimParams memory params) external returns (uint256) {
+        uint256 claimId = _bullaClaim.createClaimFrom(msg.sender, params);
+        _recordCreatedClaim(claimId);
+        return claimId;
+    }
+
+    function createClaimWithMetadata(CreateClaimParams memory params, ClaimMetadata memory metadata)
+        external
+        returns (uint256)
+    {
+        uint256 claimId = _bullaClaim.createClaimWithMetadataFrom(msg.sender, params, metadata);
+        _recordCreatedClaim(claimId);
+        return claimId;
+    }
+
+    function payClaim(uint256 claimId, uint256 amount) external payable {
+        _bullaClaim.payClaimFrom{value: msg.value}(msg.sender, claimId, amount);
+    }
+
+    function updateBinding(uint256 claimId, uint8 binding) external {
+        _bullaClaim.updateBindingFrom(msg.sender, claimId, binding);
+    }
+
+    function cancelClaim(uint256 claimId, string memory note) external {
+        _bullaClaim.cancelClaimFrom(msg.sender, claimId, note);
+    }
+
+    function burn(uint256 tokenId) external {
+        _bullaClaim.burn(tokenId);
+    }
+
+    /**
+     * @notice Records a claim ID as created through this contract
+     * @param claimId The ID of the claim that was created
+     */
+    function _recordCreatedClaim(uint256 claimId) private {
+        if (!_isClaimCreatedHere[claimId]) {
+            _createdClaimIds.push(claimId);
+            _isClaimCreatedHere[claimId] = true;
+        }
+    }
+
+    /**
+     * @notice Get all claim IDs created through this contract
+     * @return Array of claim IDs
+     */
+    function getCreatedClaimIds() external view returns (uint256[] memory) {
+        return _createdClaimIds;
+    }
+
+    /**
+     * @notice Check if a claim was created through this contract
+     * @param claimId The ID of the claim to check
+     * @return True if the claim was created through this contract
+     */
+    function isClaimCreatedHere(uint256 claimId) external view returns (bool) {
+        return _isClaimCreatedHere[claimId];
+    }
+
+    /**
+     * @notice Get the total number of claims created through this contract
+     * @return The number of claims created
+     */
+    function getCreatedClaimCount() external view returns (uint256) {
+        return _createdClaimIds.length;
+    }
+}

--- a/src/interfaces/IBullaClaim.sol
+++ b/src/interfaces/IBullaClaim.sol
@@ -142,9 +142,9 @@ interface IBullaClaim {
 
     function payClaimFrom(address from, uint256 claimId, uint256 amount) external payable;
 
-    function updateBinding(uint256 claimId, uint8 binding) external;
+    function updateBinding(uint256 claimId, ClaimBinding binding) external;
 
-    function updateBindingFrom(address from, uint256 claimId, uint8 binding) external;
+    function updateBindingFrom(address from, uint256 claimId, ClaimBinding binding) external;
 
     function cancelClaim(uint256 claimId, string memory note) external;
 

--- a/src/interfaces/IBullaClaim.sol
+++ b/src/interfaces/IBullaClaim.sol
@@ -13,7 +13,7 @@ interface IBullaClaim {
     error CannotBindClaim();
     error InvalidApproval();
     error InvalidSignature();
-    error InvalidTimestamp();
+    error ApprovalExpired();
     error PastApprovalDeadline();
     error NotOwner();
     error NotCreditorOrDebtor();

--- a/src/libraries/BullaClaimPermitLib.sol
+++ b/src/libraries/BullaClaimPermitLib.sol
@@ -12,6 +12,8 @@ library BullaClaimPermitLib {
     using Strings for uint256;
     using Strings for address;
 
+    error ApprovalExpired();
+
     event CreateClaimApproved(
         address indexed user,
         address indexed operator,
@@ -458,7 +460,7 @@ library BullaClaimPermitLib {
 
         if (!SignatureChecker.isValidSignatureNow(user, digest, signature)) revert BullaClaim.InvalidSignature();
         if (approvalDeadline != 0 && (approvalDeadline < block.timestamp || approvalDeadline > type(uint40).max)) {
-            revert BullaClaim.InvalidTimestamp();
+            revert ApprovalExpired();
         }
 
         if (approvalType == PayClaimApprovalType.IsApprovedForAll) {
@@ -482,7 +484,7 @@ library BullaClaimPermitLib {
                                 || paymentApprovals[i].approvalDeadline > type(uint40).max
                         )
                 ) {
-                    revert BullaClaim.InvalidTimestamp();
+                    revert ApprovalExpired();
                 }
 
                 approvals.payClaim.claimApprovals.push(

--- a/src/libraries/BullaClaimPermitLib.sol
+++ b/src/libraries/BullaClaimPermitLib.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.15;
 import "contracts/types/Types.sol";
 import "contracts/interfaces/IERC1271.sol";
 import "contracts/BullaClaim.sol";
+import "contracts/interfaces/IBullaClaim.sol";
 import {BullaExtensionRegistry} from "contracts/BullaExtensionRegistry.sol";
 import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
 import {SignatureChecker} from "openzeppelin-contracts/contracts/utils/cryptography/SignatureChecker.sol";
@@ -11,8 +12,6 @@ import {SignatureChecker} from "openzeppelin-contracts/contracts/utils/cryptogra
 library BullaClaimPermitLib {
     using Strings for uint256;
     using Strings for address;
-
-    error ApprovalExpired();
 
     event CreateClaimApproved(
         address indexed user,
@@ -460,7 +459,7 @@ library BullaClaimPermitLib {
 
         if (!SignatureChecker.isValidSignatureNow(user, digest, signature)) revert BullaClaim.InvalidSignature();
         if (approvalDeadline != 0 && (approvalDeadline < block.timestamp || approvalDeadline > type(uint40).max)) {
-            revert ApprovalExpired();
+            revert IBullaClaim.ApprovalExpired();
         }
 
         if (approvalType == PayClaimApprovalType.IsApprovedForAll) {
@@ -484,7 +483,7 @@ library BullaClaimPermitLib {
                                 || paymentApprovals[i].approvalDeadline > type(uint40).max
                         )
                 ) {
-                    revert ApprovalExpired();
+                    revert IBullaClaim.ApprovalExpired();
                 }
 
                 approvals.payClaim.claimApprovals.push(

--- a/src/mocks/PenalizedClaim.sol
+++ b/src/mocks/PenalizedClaim.sol
@@ -10,56 +10,54 @@ import {BullaClaim, CreateClaimParams, BullaClaim} from "contracts/BullaClaim.so
 //   note: all claim creation / mutation methods like createClaim, payClaim, acceptClaim,
 //   and cancelClaim have to be routed through this contract.
 
-contract PenalizedClaim {
+contract PenalizedClaim is BullaClaimControllerBase {
     using SafeTransferLib for *;
 
     uint256 LATE_FEE_BPS = 500;
-    BullaClaim bullaClaim;
 
     error NotController(address controller);
 
-    constructor(address _bullaClaimAddress) {
-        bullaClaim = BullaClaim(_bullaClaimAddress);
-    }
+    // We removed dueBy from the invoice struct, so we need to store it separately, hardcode to 30 days for tests
+    mapping(uint256 => uint256) public _dueByByClaimId;
+
+    constructor(address _bullaClaimAddress) BullaClaimControllerBase(_bullaClaimAddress) {}
 
     function createClaim(CreateClaimParams calldata claimParams) public returns (uint256) {
-        _checkController(claimParams.controller);
-        return bullaClaim.createClaimFrom(msg.sender, claimParams);
+        uint256 claimId = _bullaClaim.createClaimFrom(msg.sender, claimParams);
+        _dueByByClaimId[claimId] = block.timestamp + 30 days;
+        return claimId;
     }
 
     function payClaim(uint256 claimId, uint256 amount) public payable {
-        Claim memory claim = bullaClaim.getClaim(claimId);
+        Claim memory claim = _bullaClaim.getClaim(claimId);
         _checkController(claim.controller);
 
         uint256 amountToPay = amount;
 
-        if (claim.binding == ClaimBinding.Bound && claim.dueBy < block.timestamp) {
+        if (claim.binding == ClaimBinding.Bound && _dueByByClaimId[claimId] < block.timestamp) {
             uint256 lateFee = (LATE_FEE_BPS * claim.claimAmount) / 10000;
             amountToPay -= lateFee;
-            address creditor = bullaClaim.ownerOf(claimId);
+            address creditor = _bullaClaim.ownerOf(claimId);
 
             claim.token == address(0)
                 ? creditor.safeTransferETH(lateFee)
                 : ERC20(claim.token).safeTransferFrom(msg.sender, creditor, lateFee);
         }
 
-        bullaClaim.payClaimFrom{value: claim.token == address(0) ? amountToPay : 0}(msg.sender, claimId, amountToPay);
+        _bullaClaim.payClaimFrom{value: claim.token == address(0) ? amountToPay : 0}(msg.sender, claimId, amountToPay);
     }
 
     function cancelClaim(uint256 claimId, string calldata note) public {
-        Claim memory claim = bullaClaim.getClaim(claimId);
+        Claim memory claim = _bullaClaim.getClaim(claimId);
         _checkController(claim.controller);
 
-        bullaClaim.cancelClaimFrom(msg.sender, claimId, note);
+        _bullaClaim.cancelClaimFrom(msg.sender, claimId, note);
     }
 
     function acceptClaim(uint256 claimId) public {
-        bullaClaim.updateBindingFrom(msg.sender, claimId, ClaimBinding.Bound);
-    }
+        Claim memory claim = _bullaClaim.getClaim(claimId);
+        _checkController(claim.controller);
 
-    function _checkController(address _controller) internal view {
-        if (_controller != address(this)) {
-            revert NotController(_controller);
-        }
+        _bullaClaim.updateBindingFrom(msg.sender, claimId, ClaimBinding.Bound);
     }
 }

--- a/src/mocks/PenalizedClaim.sol
+++ b/src/mocks/PenalizedClaim.sol
@@ -5,7 +5,7 @@ import "contracts/types/Types.sol";
 import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {BullaClaim, CreateClaimParams, BullaClaim} from "contracts/BullaClaim.sol";
-
+import "contracts/BullaClaimControllerBase.sol";
 // naive implementation of a bullaExtension and a controller that penalizes users for paying late:
 //   note: all claim creation / mutation methods like createClaim, payClaim, acceptClaim,
 //   and cancelClaim have to be routed through this contract.

--- a/src/mocks/PenalizedClaim.sol
+++ b/src/mocks/PenalizedClaim.sol
@@ -15,14 +15,14 @@ contract PenalizedClaim is BullaClaimControllerBase {
 
     uint256 LATE_FEE_BPS = 500;
 
-    // We removed dueBy from the invoice struct, so we need to store it separately, hardcode to 30 days for tests
+    // We removed dueBy from the invoice struct, so we need to store it separately, hardcode to 1 day for tests
     mapping(uint256 => uint256) public _dueByByClaimId;
 
     constructor(address _bullaClaimAddress) BullaClaimControllerBase(_bullaClaimAddress) {}
 
     function createClaim(CreateClaimParams calldata claimParams) public returns (uint256) {
         uint256 claimId = _bullaClaim.createClaimFrom(msg.sender, claimParams);
-        _dueByByClaimId[claimId] = block.timestamp + 30 days;
+        _dueByByClaimId[claimId] = block.timestamp + 1 days;
         return claimId;
     }
 

--- a/src/types/Types.sol
+++ b/src/types/Types.sol
@@ -45,7 +45,6 @@ struct CreateClaimParams {
     address creditor;
     address debtor;
     uint256 claimAmount;
-    uint256 dueBy;
     string description;
     address token;
     address controller;
@@ -61,13 +60,12 @@ struct ClaimMetadata {
 struct ClaimStorage {
     uint128 claimAmount;
     uint128 paidAmount;
-    Status status;
-    ClaimBinding binding; // the debtor can allow themselves to be bound to a claim, which makes a claim unrejectable
-    bool payerReceivesClaimOnPayment; // an optional flag which allows the token to be transferred to the payer, acting as a "receipt NFT"
-    uint40 dueBy;
     address debtor;
     address token; // the token address that the claim is denominated in. NOTE: if this token is address(0), we treat this as a native token
     address controller;
+    Status status;
+    ClaimBinding binding; // the debtor can allow themselves to be bound to a claim, which makes a claim unrejectable
+    bool payerReceivesClaimOnPayment; // an optional flag which allows the token to be transferred to the payer, acting as a "receipt NFT"
 } // takes 4 storage slots
 
 // a cheaper struct for working / manipulating memory (unpacked is cheapter)
@@ -78,7 +76,6 @@ struct Claim {
     ClaimBinding binding;
     bool payerReceivesClaimOnPayment;
     address debtor;
-    uint256 dueBy;
     address token;
     address controller;
 }

--- a/test/foundry/BullaClaim/BullaClaimTestHelper.sol
+++ b/test/foundry/BullaClaim/BullaClaimTestHelper.sol
@@ -22,7 +22,6 @@ contract BullaClaimTestHelper is Test {
                 debtor: _debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -38,7 +37,6 @@ contract BullaClaimTestHelper is Test {
                 debtor: _debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -57,7 +55,6 @@ contract BullaClaimTestHelper is Test {
                 debtor: _debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/BurnClaim.t.sol
+++ b/test/foundry/BullaClaim/BurnClaim.t.sol
@@ -32,7 +32,6 @@ contract TestBurnClaim is Test {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/CancelClaim.t.sol
+++ b/test/foundry/BullaClaim/CancelClaim.t.sol
@@ -49,7 +49,6 @@ contract TestCancelClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: binding,
                 payerReceivesClaimOnPayment: true
@@ -383,7 +382,6 @@ contract TestCancelClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -422,7 +420,6 @@ contract TestCancelClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/CreateClaim/CreateClaim.t.sol
+++ b/test/foundry/BullaClaim/CreateClaim/CreateClaim.t.sol
@@ -20,7 +20,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
         address indexed creditor,
         address indexed debtor,
         uint256 claimAmount,
-        uint256 dueBy,
         string description,
         address token,
         address controller,
@@ -49,7 +48,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -79,7 +77,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: uint256(type(uint128).max) + 1,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -95,7 +92,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: uint256(type(uint128).max) + 1,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -112,7 +108,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.BindingPending,
                 payerReceivesClaimOnPayment: true
@@ -129,7 +124,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Bound,
                 payerReceivesClaimOnPayment: true
@@ -146,24 +140,25 @@ contract TestCreateClaim is BullaClaimTestHelper {
         assertEq(bullaClaim.currentClaimId(), beforeClaimCreation + 1);
     }
 
-    function testCreateEdgeCase_ZeroDueBy() public {
-        uint256 beforeClaimCreation = bullaClaim.currentClaimId();
-        vm.prank(creditor);
-        uint256 claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                dueBy: 0,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
-        );
-        assertEq(bullaClaim.currentClaimId(), claimId);
-        assertEq(bullaClaim.currentClaimId(), beforeClaimCreation + 1);
-    }
+    //TODO: add test in BullaInvoice
+    // function testCreateEdgeCase_ZeroDueBy() public {
+    //     uint256 beforeClaimCreation = bullaClaim.currentClaimId();
+    //     vm.prank(creditor);
+    //     uint256 claimId = bullaClaim.createClaim(
+    //         CreateClaimParams({
+    //             creditor: creditor,
+    //             debtor: debtor,
+    //             description: "",
+    //             claimAmount: 1 ether,
+    //             dueBy: 0,
+    //             token: address(weth),
+    //             binding: ClaimBinding.Unbound,
+    //             payerReceivesClaimOnPayment: true
+    //         })
+    //     );
+    //     assertEq(bullaClaim.currentClaimId(), claimId);
+    //     assertEq(bullaClaim.currentClaimId(), beforeClaimCreation + 1);
+    // }
 
     function testCannotCreateBoundClaimUnlessDebtor() public {
         vm.prank(debtor);
@@ -174,7 +169,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Bound,
                 payerReceivesClaimOnPayment: true
@@ -189,7 +183,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Bound,
                 payerReceivesClaimOnPayment: true
@@ -207,7 +200,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: claimAmount,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -215,25 +207,26 @@ contract TestCreateClaim is BullaClaimTestHelper {
         );
     }
 
-    function testCannotCreateOverDueClaim() public {
-        vm.warp(block.timestamp + 6 days);
+    //TODO: add test in BullaInvoice
+    // function testCannotCreateOverDueClaim() public {
+    //     vm.warp(block.timestamp + 6 days);
 
-        uint256 dueBy = block.timestamp - 1 days;
-        vm.expectRevert(BullaClaim.InvalidTimestamp.selector);
-        vm.prank(creditor);
-        bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                dueBy: dueBy,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
-        );
-    }
+    //     uint256 dueBy = block.timestamp - 1 days;
+    //     vm.expectRevert(BullaClaim.InvalidTimestamp.selector);
+    //     vm.prank(creditor);
+    //     bullaClaim.createClaim(
+    //         CreateClaimParams({
+    //             creditor: creditor,
+    //             debtor: debtor,
+    //             description: "",
+    //             claimAmount: 1 ether,
+    //             dueBy: dueBy,
+    //             token: address(weth),
+    //             binding: ClaimBinding.Unbound,
+    //             payerReceivesClaimOnPayment: true
+    //         })
+    //     );
+    // }
 
     function testCannotCreateZeroAmountClaim() public {
         vm.expectRevert(BullaClaim.ZeroAmount.selector);
@@ -244,7 +237,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 0,
-                dueBy: 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -261,7 +253,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Bound,
                 payerReceivesClaimOnPayment: true
@@ -269,17 +260,16 @@ contract TestCreateClaim is BullaClaimTestHelper {
         );
     }
 
+    //TODO: add similar test in BullaInvoice but with dueBy
     function test_FUZZ_createClaim(
         bool isInvoice,
         address _creditor,
         address _debtor,
         uint128 claimAmount,
         address token,
-        uint40 dueBy,
         uint8 binding,
         bool payerReceivesClaimOnPayment
     ) public {
-        vm.assume(dueBy > block.timestamp + 6 days);
         vm.assume(_creditor != address(0));
         vm.assume(claimAmount > 0);
         vm.assume(binding <= 1); // assumes a fuzz can only produce unbound or binding pending claims
@@ -297,7 +287,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
             _creditor,
             _debtor,
             uint256(claimAmount),
-            uint256(dueBy),
             "test description",
             token,
             address(0),
@@ -311,7 +300,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
                 debtor: _debtor,
                 description: "test description",
                 claimAmount: claimAmount,
-                dueBy: dueBy,
                 token: token,
                 binding: ClaimBinding(binding),
                 payerReceivesClaimOnPayment: payerReceivesClaimOnPayment
@@ -326,7 +314,6 @@ contract TestCreateClaim is BullaClaimTestHelper {
             assertTrue(claim.status == Status.Pending);
             assertEq(claim.claimAmount, claimAmount);
             assertEq(claim.debtor, _debtor);
-            assertEq(claim.dueBy, dueBy);
             assertEq(claim.payerReceivesClaimOnPayment, payerReceivesClaimOnPayment);
             assertTrue(claim.binding == ClaimBinding(binding));
             assertEq(claim.token, token);

--- a/test/foundry/BullaClaim/CreateClaim/CreateClaimFrom.t.sol
+++ b/test/foundry/BullaClaim/CreateClaim/CreateClaimFrom.t.sol
@@ -38,7 +38,6 @@ contract TestCreateClaimFrom is BullaClaimTestHelper {
         address indexed creditor,
         address indexed debtor,
         uint256 claimAmount,
-        uint256 dueBy,
         string description,
         address token,
         address controller,
@@ -114,7 +113,6 @@ contract TestCreateClaimFrom is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -223,7 +221,6 @@ contract TestCreateClaimFrom is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Bound, // binding is set to bound
                 payerReceivesClaimOnPayment: true
@@ -266,7 +263,6 @@ contract TestCreateClaimFrom is BullaClaimTestHelper {
                 isInvoice ? _user : debtor,
                 isInvoice ? debtor : _user,
                 1 ether,
-                block.timestamp + 1 days,
                 "fuzzzin",
                 address(0),
                 _operator,
@@ -282,7 +278,6 @@ contract TestCreateClaimFrom is BullaClaimTestHelper {
                 debtor: isInvoice ? debtor : _user,
                 description: "fuzzzin",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: _isBindingAllowed && !isInvoice ? ClaimBinding.Bound : ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/CreateClaim/CreateClaimWithMetadata.t.sol
+++ b/test/foundry/BullaClaim/CreateClaim/CreateClaimWithMetadata.t.sol
@@ -57,7 +57,6 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -111,7 +110,6 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
                 debtor: user,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Bound,
                 payerReceivesClaimOnPayment: true
@@ -137,7 +135,6 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
                 debtor: user,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -163,7 +160,6 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
                 debtor: creditor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/DelegatedClaims_PenalizedClaims.t.sol
+++ b/test/foundry/BullaClaim/DelegatedClaims_PenalizedClaims.t.sol
@@ -57,7 +57,6 @@ contract TestPenalizedClaim is Test {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.BindingPending,
                 payerReceivesClaimOnPayment: true
@@ -127,7 +126,6 @@ contract TestPenalizedClaim is Test {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.BindingPending,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/EIP712/PermitPayClaim/Common.t.sol
+++ b/test/foundry/BullaClaim/EIP712/PermitPayClaim/Common.t.sol
@@ -43,7 +43,6 @@ contract PermitPayClaimTest is Test {
                 debtor: _debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/EIP712/PermitPayClaim/PermitIsApprovedForAll.t.sol
+++ b/test/foundry/BullaClaim/EIP712/PermitPayClaim/PermitIsApprovedForAll.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.15;
 
 import "test/foundry/BullaClaim/EIP712/PermitPayClaim/Common.t.sol";
+import "contracts/interfaces/IBullaClaim.sol";
 
 /// @notice SPEC
 /// permitPayClaim() can approve an operator to pay _all_ claims given the following conditions listed below as AA - (Approve All 1-5):
@@ -191,7 +192,7 @@ contract TestPermitPayClaim_IsApprovedForAll is PermitPayClaimTest {
             paymentApprovals: new ClaimPaymentApprovalParam[](0)
         });
 
-        vm.expectRevert(BullaClaim.InvalidTimestamp.selector);
+        vm.expectRevert(IBullaClaim.ApprovalExpired.selector);
         bullaClaim.permitPayClaim({
             user: alice,
             operator: bob,
@@ -213,7 +214,7 @@ contract TestPermitPayClaim_IsApprovedForAll is PermitPayClaimTest {
             paymentApprovals: new ClaimPaymentApprovalParam[](0)
         });
 
-        vm.expectRevert(BullaClaim.InvalidTimestamp.selector);
+        vm.expectRevert(IBullaClaim.ApprovalExpired.selector);
         bullaClaim.permitPayClaim({
             user: alice,
             operator: bob,
@@ -238,7 +239,7 @@ contract TestPermitPayClaim_IsApprovedForAll is PermitPayClaimTest {
             paymentApprovals: new ClaimPaymentApprovalParam[](0)
         });
 
-        vm.expectRevert(BullaClaim.InvalidTimestamp.selector);
+        vm.expectRevert(IBullaClaim.ApprovalExpired.selector);
         bullaClaim.permitPayClaim({
             user: alice,
             operator: bob,

--- a/test/foundry/BullaClaim/EIP712/PermitPayClaim/PermitIsApprovedForSpecific.t.sol
+++ b/test/foundry/BullaClaim/EIP712/PermitPayClaim/PermitIsApprovedForSpecific.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.15;
 
 import "test/foundry/BullaClaim/EIP712/PermitPayClaim/Common.t.sol";
+import "contracts/interfaces/IBullaClaim.sol";
 
 /// @notice SPEC
 /// permitPayClaim can approve an operator to pay _specific_ claims given the following conditions listed below as AS - (Approve Specific 1-5):
@@ -217,7 +218,7 @@ contract TestPermitPayClaim_IsApprovedForSpecific is PermitPayClaimTest {
             paymentApprovals: paymentApprovals
         });
 
-        vm.expectRevert(BullaClaim.InvalidTimestamp.selector);
+        vm.expectRevert(IBullaClaim.ApprovalExpired.selector);
         bullaClaim.permitPayClaim({
             user: alice,
             operator: bob,
@@ -294,7 +295,7 @@ contract TestPermitPayClaim_IsApprovedForSpecific is PermitPayClaimTest {
             paymentApprovals: paymentApprovals
         });
 
-        vm.expectRevert(BullaClaim.InvalidTimestamp.selector);
+        vm.expectRevert(IBullaClaim.ApprovalExpired.selector);
         bullaClaim.permitPayClaim({
             user: alice,
             operator: bob,
@@ -322,7 +323,7 @@ contract TestPermitPayClaim_IsApprovedForSpecific is PermitPayClaimTest {
             paymentApprovals: paymentApprovals
         });
 
-        vm.expectRevert(BullaClaim.InvalidTimestamp.selector);
+        vm.expectRevert(IBullaClaim.ApprovalExpired.selector);
         bullaClaim.permitPayClaim({
             user: alice,
             operator: bob,
@@ -349,7 +350,7 @@ contract TestPermitPayClaim_IsApprovedForSpecific is PermitPayClaimTest {
             paymentApprovals: paymentApprovals
         });
 
-        vm.expectRevert(BullaClaim.InvalidTimestamp.selector);
+        vm.expectRevert(IBullaClaim.ApprovalExpired.selector);
         bullaClaim.permitPayClaim({
             user: alice,
             operator: bob,

--- a/test/foundry/BullaClaim/ERC721.t.sol
+++ b/test/foundry/BullaClaim/ERC721.t.sol
@@ -26,7 +26,6 @@ contract ERC721Test is DSTestPlus {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -42,7 +41,6 @@ contract ERC721Test is DSTestPlus {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -137,7 +135,6 @@ contract ERC721Test is DSTestPlus {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/PayClaim/PayClaim.t.sol
+++ b/test/foundry/BullaClaim/PayClaim/PayClaim.t.sol
@@ -46,7 +46,6 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: claimAmount,
-                dueBy: block.timestamp + 1 days,
                 token: isNative ? address(0) : address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -96,7 +95,6 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: false
@@ -170,7 +168,6 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: false

--- a/test/foundry/BullaClaim/PayClaim/PayClaimFrom.t.sol
+++ b/test/foundry/BullaClaim/PayClaim/PayClaimFrom.t.sol
@@ -339,7 +339,6 @@ contract TestPayClaimFrom is BullaClaimTestHelper {
                 debtor: user,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0), // native token
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/PayClaim/PayClaimWithWeirdTokens.t.sol
+++ b/test/foundry/BullaClaim/PayClaim/PayClaimWithWeirdTokens.t.sol
@@ -65,7 +65,6 @@ contract TestPayClaimWithWeirdTokens is Test {
                 debtor: debtor,
                 description: "",
                 claimAmount: claimAmount,
-                dueBy: block.timestamp + 1 days,
                 token: token,
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/TestInvariants.t.sol
+++ b/test/foundry/BullaClaim/TestInvariants.t.sol
@@ -38,7 +38,6 @@ contract TestInvariants is Test {
         address indexed creditor,
         address indexed debtor,
         uint256 claimAmount,
-        uint256 dueBy,
         string description,
         address token,
         address controller,
@@ -104,7 +103,6 @@ contract TestInvariants is Test {
             creditor,
             debtor,
             uint256(_claimAmount),
-            uint256(block.timestamp + 1 days),
             "",
             address(weth),
             address(0),
@@ -118,7 +116,6 @@ contract TestInvariants is Test {
                 debtor: debtor,
                 description: "",
                 claimAmount: _claimAmount,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/TokenURI.t.sol
+++ b/test/foundry/BullaClaim/TokenURI.t.sol
@@ -34,7 +34,6 @@ contract TestTokenURI is Test {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -56,7 +55,6 @@ contract TestTokenURI is Test {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true
@@ -82,7 +80,6 @@ contract TestTokenURI is Test {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(0),
                 binding: ClaimBinding.Unbound,
                 payerReceivesClaimOnPayment: true

--- a/test/foundry/BullaClaim/UpdateBinding.t.sol
+++ b/test/foundry/BullaClaim/UpdateBinding.t.sol
@@ -45,7 +45,6 @@ contract TestUpdateBinding is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: binding,
                 payerReceivesClaimOnPayment: true
@@ -393,7 +392,6 @@ contract TestUpdateBinding is BullaClaimTestHelper {
                 debtor: debtor,
                 description: "",
                 claimAmount: 1 ether,
-                dueBy: block.timestamp + 1 days,
                 token: address(weth),
                 binding: ClaimBinding.BindingPending,
                 payerReceivesClaimOnPayment: true


### PR DESCRIPTION
Targeting a long living feature branch for this because the tests wont compile for the immediate future. (edit: they do compile but we aren't testing dueBy at the moment, will create more tests for BullaInvoice once this passes or tomorrow in this PR, what ever is easiest to review)

- Create BullaInvoice contract as the BullaClaim that we know and love
- Moving things from BullaClaim to aforementioned BullaInvoice

not seen in this PR, I removed the ability to create claims directly from the BullaClaim contract, but later decided to allow it, since we can't truly ban it, it made no sense.

So lots of work was added then removed, it is what it is.