### PR TITLE
Add builder for CreateClaimParams

### DIFF
--- a/test/foundry/BullaClaim/BullaClaimTestHelper.sol
+++ b/test/foundry/BullaClaim/BullaClaimTestHelper.sol
@@ -16,24 +16,33 @@ contract BullaClaimTestHelper is Test {
     string attachmentURI = "https://coolcatpics.com/1234";
 
     function _newClaim(address _creator, address _creditor, address _debtor) internal returns (uint256 claimId) {
-        vm.prank(_creator);
+        vm.startPrank(_creator);
         claimId = bullaClaim.createClaim(
-            new CreateClaimParamsBuilder()
-                .withCreditor(_creditor)
-                .withDebtor(_debtor)
-                .withToken(address(weth))
-                .build()
+            CreateClaimParams({
+                creditor: _creditor,
+                debtor: _debtor,
+                token: address(weth),
+                description: "",
+                binding: ClaimBinding.Unbound,
+                claimAmount: 1 ether,
+                payerReceivesClaimOnPayment: true
+            })
         );
+        vm.stopPrank();
     }
 
     function _newClaimFrom(address _from, address _creditor, address _debtor) internal returns (uint256 claimId) {
         claimId = bullaClaim.createClaimFrom(
             _from,
-            new CreateClaimParamsBuilder()
-                .withCreditor(_creditor)
-                .withDebtor(_debtor)
-                .withToken(address(weth))
-                .build()
+            CreateClaimParams({
+                creditor: _creditor,
+                debtor: _debtor,
+                token: address(weth),
+                description: "",
+                binding: ClaimBinding.Unbound,
+                claimAmount: 1 ether,
+                payerReceivesClaimOnPayment: true
+            })
         );
     }
 
@@ -43,11 +52,15 @@ contract BullaClaimTestHelper is Test {
     {
         claimId = bullaClaim.createClaimWithMetadataFrom(
             _from,
-            new CreateClaimParamsBuilder()
-                .withCreditor(_creditor)
-                .withDebtor(_debtor)
-                .withToken(address(weth))
-                .build(),
+            CreateClaimParams({
+                creditor: _creditor,
+                debtor: _debtor,
+                token: address(weth),
+                description: "",
+                binding: ClaimBinding.Unbound,
+                claimAmount: 1 ether,
+                payerReceivesClaimOnPayment: true
+            }),
             ClaimMetadata({tokenURI: tokenURI, attachmentURI: attachmentURI})
         );
     }

--- a/test/foundry/BullaClaim/BullaClaimTestHelper.sol
+++ b/test/foundry/BullaClaim/BullaClaimTestHelper.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 import {WETH} from "contracts/mocks/weth.sol";
 import "contracts/BullaClaim.sol";
 import {EIP712Helper} from "test/foundry/BullaClaim/EIP712/Utils.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 contract BullaClaimTestHelper is Test {
     WETH public weth;
@@ -17,30 +18,22 @@ contract BullaClaimTestHelper is Test {
     function _newClaim(address _creator, address _creditor, address _debtor) internal returns (uint256 claimId) {
         vm.prank(_creator);
         claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: _creditor,
-                debtor: _debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(_creditor)
+                .withDebtor(_debtor)
+                .withToken(address(weth))
+                .build()
         );
     }
 
     function _newClaimFrom(address _from, address _creditor, address _debtor) internal returns (uint256 claimId) {
         claimId = bullaClaim.createClaimFrom(
             _from,
-            CreateClaimParams({
-                creditor: _creditor,
-                debtor: _debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(_creditor)
+                .withDebtor(_debtor)
+                .withToken(address(weth))
+                .build()
         );
     }
 
@@ -50,15 +43,11 @@ contract BullaClaimTestHelper is Test {
     {
         claimId = bullaClaim.createClaimWithMetadataFrom(
             _from,
-            CreateClaimParams({
-                creditor: _creditor,
-                debtor: _debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            }),
+            new CreateClaimParamsBuilder()
+                .withCreditor(_creditor)
+                .withDebtor(_debtor)
+                .withToken(address(weth))
+                .build(),
             ClaimMetadata({tokenURI: tokenURI, attachmentURI: attachmentURI})
         );
     }

--- a/test/foundry/BullaClaim/CancelClaim.t.sol
+++ b/test/foundry/BullaClaim/CancelClaim.t.sol
@@ -9,6 +9,7 @@ import {BullaClaim} from "contracts/BullaClaim.sol";
 import {EIP712Helper, privateKeyValidity} from "test/foundry/BullaClaim/EIP712/Utils.sol";
 import {Deployer} from "script/Deployment.s.sol";
 import {BullaClaimTestHelper} from "test/foundry/BullaClaim/BullaClaimTestHelper.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 /// @notice covers test cases for cancelClaim() and cancelClaimFrom()
 /// @notice SPEC: canceClaim() TODO
@@ -44,15 +45,12 @@ contract TestCancelClaim is BullaClaimTestHelper {
 
     function _newClaim(ClaimBinding binding) internal returns (uint256 claimId, Claim memory claim) {
         claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: binding,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .withBinding(binding)
+                .build()
         );
         claim = bullaClaim.getClaim(claimId);
     }
@@ -358,15 +356,11 @@ contract TestCancelClaim is BullaClaimTestHelper {
         vm.prank(operator);
         uint256 claimId = bullaClaim.createClaimFrom(
             creditor,
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .build()
         );
 
         vm.prank(debtor);
@@ -396,15 +390,11 @@ contract TestCancelClaim is BullaClaimTestHelper {
         vm.prank(operator);
         uint256 claimId = bullaClaim.createClaimFrom(
             creditor,
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .build()
         );
 
         _permitCancelClaim({_userPK: creditorPK, _operator: operator, _approvalCount: type(uint64).max});

--- a/test/foundry/BullaClaim/CancelClaim.t.sol
+++ b/test/foundry/BullaClaim/CancelClaim.t.sol
@@ -62,8 +62,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
 
     /// @notice SPEC._spendCancelClaimApproval.S1
     function testRejectsIfDebtor() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId, Claim memory claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
         string memory note = "No thanks";
 
         vm.expectEmit(true, true, true, true);
@@ -76,10 +77,10 @@ contract TestCancelClaim is BullaClaimTestHelper {
         assertTrue(claim.status == Status.Rejected);
 
         // test with operator
-        vm.prank(creditor);
-
+        vm.startPrank(creditor);
         // make a new claim
         (claimId, claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
         assertTrue(claimId == 2);
 
         // permit an operator
@@ -97,8 +98,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
 
     /// @notice SPEC._spendCancelClaimApproval.S1
     function testRescindsIfCreditor() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId, Claim memory claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
         string memory note = "No thanks";
 
         vm.expectEmit(true, true, true, true);
@@ -111,9 +113,10 @@ contract TestCancelClaim is BullaClaimTestHelper {
         assertTrue(claim.status == Status.Rescinded);
 
         // test with operator
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         // make a new claim
         (claimId, claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
         assertTrue(claimId == 2);
 
         // permit an operator
@@ -133,8 +136,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
         vm.assume(privateKeyValidity(callerPK) && callerPK != creditorPK && callerPK != debtorPK);
         address randomAddress = vm.addr(callerPK);
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
         string memory note = "No thanks";
 
         vm.prank(randomAddress);
@@ -150,8 +154,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
     }
 
     function testCannotCancelIfLocked() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         _setLockState(LockState.Locked);
 
@@ -178,8 +183,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
 
     function testCanCancelIfPartiallyLocked() public {
         // creditor creates and debtor rejects
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId, Claim memory claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         _setLockState(LockState.NoNewClaims);
 
@@ -191,8 +197,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
         // creditor creates and rescinds
         _setLockState(LockState.Unlocked);
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId, claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         _setLockState(LockState.NoNewClaims);
 
@@ -207,8 +214,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
         _permitCancelClaim({_userPK: creditorPK, _operator: operator, _approvalCount: type(uint64).max});
 
         // creditor creates and operator rejects for debtor
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId, Claim memory claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         _setLockState(LockState.NoNewClaims);
 
@@ -220,8 +228,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
         // creditor creates and operator rejects for creditor
         _setLockState(LockState.Unlocked);
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId, claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         _setLockState(LockState.NoNewClaims);
 
@@ -232,8 +241,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
     }
 
     function testCanCancelWhenBindingPending() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId, Claim memory claim) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
         string memory note = "No thanks";
 
         vm.expectEmit(true, true, true, true);
@@ -246,10 +256,10 @@ contract TestCancelClaim is BullaClaimTestHelper {
         assertTrue(claim.status == Status.Rejected);
 
         // test with operator
-        vm.prank(creditor);
-
+        vm.startPrank(creditor);
         // make a new claim
         (claimId, claim) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
         assertTrue(claimId == 2);
 
         // permit an operator
@@ -263,8 +273,10 @@ contract TestCancelClaim is BullaClaimTestHelper {
 
         claim = bullaClaim.getClaim(claimId);
         assertTrue(claim.status == Status.Rejected);
-        vm.prank(creditor);
+        
+        vm.startPrank(creditor);
         (claimId, claim) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
 
         vm.expectEmit(true, true, true, true);
         emit ClaimRescinded(claimId, creditor, note);
@@ -276,9 +288,10 @@ contract TestCancelClaim is BullaClaimTestHelper {
         assertTrue(claim.status == Status.Rescinded);
 
         // test with operator
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         // make a new claim
         (claimId, claim) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
         assertTrue(claimId == 4);
 
         // permit an operator
@@ -301,8 +314,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
     }
 
     function testDebtorCannotCancelClaimIfBound() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
         string memory note = "No thanks";
 
         vm.startPrank(debtor);
@@ -320,8 +334,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
     }
 
     function testCreditorCanCancelClaimIfBound() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         vm.prank(debtor);
         bullaClaim.updateBinding(claimId, ClaimBinding.Bound);
@@ -353,14 +368,16 @@ contract TestCancelClaim is BullaClaimTestHelper {
         });
 
         // create a delegated claim
+        CreateClaimParams memory params = new CreateClaimParamsBuilder()
+            .withCreditor(creditor)
+            .withDebtor(debtor)
+            .withToken(address(weth))
+            .build();
+            
         vm.prank(operator);
         uint256 claimId = bullaClaim.createClaimFrom(
             creditor,
-            new CreateClaimParamsBuilder()
-                .withCreditor(creditor)
-                .withDebtor(debtor)
-                .withToken(address(weth))
-                .build()
+            params
         );
 
         vm.prank(debtor);
@@ -387,14 +404,16 @@ contract TestCancelClaim is BullaClaimTestHelper {
         });
 
         // create a delegated claim
+        CreateClaimParams memory params = new CreateClaimParamsBuilder()
+            .withCreditor(creditor)
+            .withDebtor(debtor)
+            .withToken(address(weth))
+            .build();
+            
         vm.prank(operator);
         uint256 claimId = bullaClaim.createClaimFrom(
             creditor,
-            new CreateClaimParamsBuilder()
-                .withCreditor(creditor)
-                .withDebtor(debtor)
-                .withToken(address(weth))
-                .build()
+            params
         );
 
         _permitCancelClaim({_userPK: creditorPK, _operator: operator, _approvalCount: type(uint64).max});
@@ -404,8 +423,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
     }
 
     function testCannotCancelIfRepaying() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         vm.deal(debtor, 10 ether);
 
@@ -423,8 +443,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
 
     /// cover all cases of double rescinding / rejecting
     function testCannotCancelIfAlreadyCancelled() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         // test double rescind
         vm.prank(creditor);
@@ -466,8 +487,9 @@ contract TestCancelClaim is BullaClaimTestHelper {
     }
 
     function testCannotCancelIfPaid() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         vm.deal(debtor, 10 ether);
 
@@ -490,8 +512,10 @@ contract TestCancelClaim is BullaClaimTestHelper {
 
         // test for reject
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
+        
         // permit an operator
         _permitCancelClaim({_userPK: debtorPK, _operator: operator, _approvalCount: approvalCount});
 
@@ -506,8 +530,10 @@ contract TestCancelClaim is BullaClaimTestHelper {
 
         // test for rescind
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
+        
         // permit an operator
         _permitCancelClaim({_userPK: creditorPK, _operator: operator, _approvalCount: approvalCount});
 
@@ -524,8 +550,10 @@ contract TestCancelClaim is BullaClaimTestHelper {
     /// @notice SPEC._spendCancelClaimApproval.S1
     function testCancelClaimFromRevertsIfUnapproved() public {
         // make a new claim
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
+        
         // permit an operator
         _permitCancelClaim({_userPK: debtorPK, _operator: operator, _approvalCount: 5});
 
@@ -540,8 +568,10 @@ contract TestCancelClaim is BullaClaimTestHelper {
     /// @notice SPEC._spendCancelClaimApproval.RES1
     function testCancelClaimFromDoesNotDecrementIfApprovalMaxedOut() public {
         // make a new claim
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
+        
         // permit an operator
         _permitCancelClaim({_userPK: debtorPK, _operator: operator, _approvalCount: type(uint64).max});
 

--- a/test/foundry/BullaClaim/CreateClaim/CreateClaimFrom.t.sol
+++ b/test/foundry/BullaClaim/CreateClaim/CreateClaimFrom.t.sol
@@ -10,6 +10,7 @@ import {BullaClaim, CreateClaimApprovalType} from "contracts/BullaClaim.sol";
 import {PenalizedClaim} from "contracts/mocks/PenalizedClaim.sol";
 import {Deployer} from "script/Deployment.s.sol";
 import {BullaClaimTestHelper} from "test/foundry/BullaClaim/BullaClaimTestHelper.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 /// @notice SPEC:
 /// A function can call this function to verify and "spend" `from`'s approval of `operator` to create a claim given the following:
@@ -108,15 +109,11 @@ contract TestCreateClaimFrom is BullaClaimTestHelper {
 
         vm.prank(creditor);
         uint256 claimId = controller.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .build()
         );
         Claim memory claim = bullaClaim.getClaim(claimId);
         assertEq(claim.controller, address(controller));
@@ -216,15 +213,12 @@ contract TestCreateClaimFrom is BullaClaimTestHelper {
         vm.expectRevert(BullaClaim.CannotBindClaim.selector);
         bullaClaim.createClaimFrom(
             user,
-            CreateClaimParams({
-                creditor: user,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Bound, // binding is set to bound
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(user)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .withBinding(ClaimBinding.Bound)
+                .build()
         );
     }
 
@@ -273,15 +267,13 @@ contract TestCreateClaimFrom is BullaClaimTestHelper {
         vm.prank(_operator);
         bullaClaim.createClaimFrom(
             _user,
-            CreateClaimParams({
-                creditor: isInvoice ? _user : debtor,
-                debtor: isInvoice ? debtor : _user,
-                description: "fuzzzin",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: _isBindingAllowed && !isInvoice ? ClaimBinding.Bound : ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(isInvoice ? _user : debtor)
+                .withDebtor(isInvoice ? debtor : _user)
+                .withDescription("fuzzzin")
+                .withToken(address(0))
+                .withBinding(_isBindingAllowed && !isInvoice ? ClaimBinding.Bound : ClaimBinding.Unbound)
+                .build()
         );
     }
 }

--- a/test/foundry/BullaClaim/CreateClaim/CreateClaimWithMetadata.t.sol
+++ b/test/foundry/BullaClaim/CreateClaim/CreateClaimWithMetadata.t.sol
@@ -171,7 +171,7 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
     function testOriginalCreditorWithMetadata() public {
         // Test with createClaimWithMetadata
         vm.prank(creditor);
-        uint256 claimId2 = bullaClaim.createClaimWithMetadata(
+        bullaClaim.createClaimWithMetadata(
             CreateClaimParams({
                 creditor: creditor,
                 debtor: debtor,

--- a/test/foundry/BullaClaim/CreateClaim/CreateClaimWithMetadata.t.sol
+++ b/test/foundry/BullaClaim/CreateClaim/CreateClaimWithMetadata.t.sol
@@ -9,6 +9,7 @@ import {BullaClaim, CreateClaimApprovalType} from "contracts/BullaClaim.sol";
 import {PenalizedClaim} from "contracts/mocks/PenalizedClaim.sol";
 import {Deployer} from "script/Deployment.s.sol";
 import {BullaClaimTestHelper} from "test/foundry/BullaClaim/BullaClaimTestHelper.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
     uint256 creditorPK = uint256(0x01);
@@ -52,15 +53,11 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
         emit MetadataAdded(1, tokenURI, attachmentURI);
         vm.prank(creditor);
         uint256 claimId = bullaClaim.createClaimWithMetadata(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            }),
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .build(),
             ClaimMetadata({tokenURI: tokenURI, attachmentURI: attachmentURI})
         );
 
@@ -105,15 +102,11 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
         vm.expectRevert(abi.encodeWithSelector(BullaClaim.CannotBindClaim.selector));
         bullaClaim.createClaimWithMetadataFrom(
             user,
-            CreateClaimParams({
-                creditor: debtor,
-                debtor: user,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Bound,
-                payerReceivesClaimOnPayment: true
-            }),
+            new CreateClaimParamsBuilder()
+                .withCreditor(debtor)
+                .withDebtor(user)
+                .withBinding(ClaimBinding.Bound)
+                .build(),
             ClaimMetadata({tokenURI: tokenURI, attachmentURI: attachmentURI})
         );
     }
@@ -130,15 +123,10 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
         vm.expectRevert(abi.encodeWithSelector(BullaClaim.NotApproved.selector));
         bullaClaim.createClaimWithMetadataFrom(
             user,
-            CreateClaimParams({
-                creditor: debtor,
-                debtor: user,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            }),
+            new CreateClaimParamsBuilder()
+                .withCreditor(debtor)
+                .withDebtor(user)
+                .build(),
             ClaimMetadata({tokenURI: tokenURI, attachmentURI: attachmentURI})
         );
     }
@@ -155,15 +143,10 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
         vm.expectRevert(abi.encodeWithSelector(BullaClaim.NotApproved.selector));
         bullaClaim.createClaimWithMetadataFrom(
             user,
-            CreateClaimParams({
-                creditor: user,
-                debtor: creditor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            }),
+            new CreateClaimParamsBuilder()
+                .withCreditor(user)
+                .withDebtor(creditor)
+                .build(),
             ClaimMetadata({tokenURI: tokenURI, attachmentURI: attachmentURI})
         );
     }
@@ -172,15 +155,11 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
         // Test with createClaimWithMetadata
         vm.prank(creditor);
         bullaClaim.createClaimWithMetadata(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            }),
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .build(),
             ClaimMetadata({tokenURI: tokenURI, attachmentURI: attachmentURI})
         );
         
@@ -194,15 +173,11 @@ contract TestCreateClaimWithMetadata is BullaClaimTestHelper {
         
         uint256 claimId3 = bullaClaim.createClaimFrom(
             user,
-            CreateClaimParams({
-                creditor: user,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(user)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .build()
         );
         
         Claim memory claim3 = bullaClaim.getClaim(claimId3);

--- a/test/foundry/BullaClaim/CreateClaimParamsBuilder.sol
+++ b/test/foundry/BullaClaim/CreateClaimParamsBuilder.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.14;
+
+import {CreateClaimParams, ClaimBinding} from "contracts/types/Types.sol";
+
+contract CreateClaimParamsBuilder {
+    address private _creditor;
+    address private _debtor;
+    uint256 private _claimAmount;
+    string private _description;
+    address private _token;
+    ClaimBinding private _binding;
+    bool private _payerReceivesClaimOnPayment;
+
+    constructor() {
+        // Default values
+        _creditor = address(0);
+        _debtor = address(0);
+        _claimAmount = 1 ether;
+        _description = "Test Claim";
+        _token = address(0); // ETH by default
+        _binding = ClaimBinding.Unbound;
+        _payerReceivesClaimOnPayment = true;
+    }
+
+    function withCreditor(address creditor) public returns (CreateClaimParamsBuilder) {
+        _creditor = creditor;
+        return this;
+    }
+
+    function withDebtor(address debtor) public returns (CreateClaimParamsBuilder) {
+        _debtor = debtor;
+        return this;
+    }
+
+    function withClaimAmount(uint256 claimAmount) public returns (CreateClaimParamsBuilder) {
+        _claimAmount = claimAmount;
+        return this;
+    }
+
+    function withDescription(string memory description) public returns (CreateClaimParamsBuilder) {
+        _description = description;
+        return this;
+    }
+
+    function withToken(address token) public returns (CreateClaimParamsBuilder) {
+        _token = token;
+        return this;
+    }
+
+    function withBinding(ClaimBinding binding) public returns (CreateClaimParamsBuilder) {
+        _binding = binding;
+        return this;
+    }
+
+    function withPayerReceivesClaimOnPayment(bool payerReceivesClaim) public returns (CreateClaimParamsBuilder) {
+        _payerReceivesClaimOnPayment = payerReceivesClaim;
+        return this;
+    }
+
+    function build() public view returns (CreateClaimParams memory) {
+        return CreateClaimParams({
+            creditor: _creditor,
+            debtor: _debtor,
+            claimAmount: _claimAmount,
+            description: _description,
+            token: _token,
+            binding: _binding,
+            payerReceivesClaimOnPayment: _payerReceivesClaimOnPayment
+        });
+    }
+} 

--- a/test/foundry/BullaClaim/DelegatedClaims_PenalizedClaims.t.sol
+++ b/test/foundry/BullaClaim/DelegatedClaims_PenalizedClaims.t.sol
@@ -10,6 +10,7 @@ import {EIP712Helper, privateKeyValidity} from "test/foundry/BullaClaim/EIP712/U
 import {BullaClaim} from "contracts/BullaClaim.sol";
 import {PenalizedClaim} from "contracts/mocks/PenalizedClaim.sol";
 import {Deployer} from "script/Deployment.s.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 contract TestPenalizedClaim is Test {
     WETH public weth;
@@ -52,15 +53,11 @@ contract TestPenalizedClaim is Test {
 
         vm.prank(creditor);
         uint256 claimId = penalizedClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.BindingPending,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withBinding(ClaimBinding.BindingPending)
+                .build()
         );
 
         bullaClaim.permitUpdateBinding({
@@ -121,15 +118,11 @@ contract TestPenalizedClaim is Test {
 
         vm.prank(creditor);
         uint256 claimId = penalizedClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.BindingPending,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withBinding(ClaimBinding.BindingPending)
+                .build()
         );
 
         vm.startPrank(debtor);

--- a/test/foundry/BullaClaim/DelegatedClaims_PenalizedClaims.t.sol
+++ b/test/foundry/BullaClaim/DelegatedClaims_PenalizedClaims.t.sol
@@ -51,7 +51,7 @@ contract TestPenalizedClaim is Test {
             })
         });
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         uint256 claimId = penalizedClaim.createClaim(
             new CreateClaimParamsBuilder()
                 .withCreditor(creditor)
@@ -59,6 +59,7 @@ contract TestPenalizedClaim is Test {
                 .withBinding(ClaimBinding.BindingPending)
                 .build()
         );
+        vm.stopPrank();
 
         bullaClaim.permitUpdateBinding({
             user: debtor,
@@ -116,7 +117,7 @@ contract TestPenalizedClaim is Test {
             })
         });
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         uint256 claimId = penalizedClaim.createClaim(
             new CreateClaimParamsBuilder()
                 .withCreditor(creditor)
@@ -124,6 +125,7 @@ contract TestPenalizedClaim is Test {
                 .withBinding(ClaimBinding.BindingPending)
                 .build()
         );
+        vm.stopPrank();
 
         vm.startPrank(debtor);
 

--- a/test/foundry/BullaClaim/EIP712/PermitPayClaim/Common.t.sol
+++ b/test/foundry/BullaClaim/EIP712/PermitPayClaim/Common.t.sol
@@ -7,6 +7,7 @@ import {ERC1271WalletMock} from "contracts/mocks/ERC1271Wallet.sol";
 import {WETH} from "contracts/mocks/weth.sol";
 import {Test} from "forge-std/Test.sol";
 import {EIP712Helper, privateKeyValidity, splitSig} from "test/foundry/BullaClaim/EIP712/Utils.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 /// @notice a base boilerplate class to inherit on PermitPayClaim tests
 contract PermitPayClaimTest is Test {
@@ -38,15 +39,11 @@ contract PermitPayClaimTest is Test {
 
     function _newClaim(address _creditor, address _debtor) internal returns (uint256 claimId) {
         claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: _creditor,
-                debtor: _debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(_creditor)
+                .withDebtor(_debtor)
+                .withToken(address(weth))
+                .build()
         );
     }
 

--- a/test/foundry/BullaClaim/ERC721.t.sol
+++ b/test/foundry/BullaClaim/ERC721.t.sol
@@ -20,23 +20,25 @@ contract ERC721Test is DSTestPlus {
     }
 
     function _mint() private returns (uint256 claimId) {
-        hevm.prank(creditor);
+        hevm.startPrank(creditor);
         claimId = token.createClaim(
             new CreateClaimParamsBuilder()
                 .withCreditor(creditor)
                 .withDebtor(debtor)
                 .build()
         );
+        hevm.stopPrank();
     }
 
     function _mint(address _creator, address _creditor) private returns (uint256 claimId) {
-        hevm.prank(_creator);
+        hevm.startPrank(_creator);
         claimId = token.createClaim(
             new CreateClaimParamsBuilder()
                 .withCreditor(_creditor)
                 .withDebtor(debtor)
                 .build()
         );
+        hevm.stopPrank();
     }
 
     function testMint() public {

--- a/test/foundry/BullaClaim/ERC721.t.sol
+++ b/test/foundry/BullaClaim/ERC721.t.sol
@@ -5,6 +5,7 @@ import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {BullaClaim} from "contracts/BullaClaim.sol";
 import {Claim, Status, ClaimBinding, LockState, CreateClaimParams} from "contracts/types/Types.sol";
 import {Deployer} from "script/Deployment.s.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 // run the solmate ERC721 spec against bulla claim to ensure functionality
 
@@ -21,30 +22,20 @@ contract ERC721Test is DSTestPlus {
     function _mint() private returns (uint256 claimId) {
         hevm.prank(creditor);
         claimId = token.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .build()
         );
     }
 
     function _mint(address _creator, address _creditor) private returns (uint256 claimId) {
         hevm.prank(_creator);
         claimId = token.createClaim(
-            CreateClaimParams({
-                creditor: _creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(_creditor)
+                .withDebtor(debtor)
+                .build()
         );
     }
 
@@ -130,15 +121,10 @@ contract ERC721Test is DSTestPlus {
 
     function testFailMintToZero() public {
         token.createClaim(
-            CreateClaimParams({
-                creditor: address(0),
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(address(0))
+                .withDebtor(debtor)
+                .build()
         );
     }
 

--- a/test/foundry/BullaClaim/PayClaim/PayClaim.t.sol
+++ b/test/foundry/BullaClaim/PayClaim/PayClaim.t.sol
@@ -40,7 +40,7 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
     event ClaimPayment(uint256 indexed claimId, address indexed paidBy, uint256 paymentAmount, uint256 totalPaidAmount);
 
     function _newClaim(address creator, bool isNative, uint256 claimAmount) private returns (uint256 claimId) {
-        vm.prank(creator);
+        vm.startPrank(creator);
         claimId = bullaClaim.createClaim(
             new CreateClaimParamsBuilder()
                 .withCreditor(creditor)
@@ -49,6 +49,7 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
                 .withToken(isNative ? address(0) : address(weth))
                 .build()
         );
+        vm.stopPrank();
     }
 
     function testPaymentNoFee() public {
@@ -86,7 +87,7 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
     }
 
     function testPayClaimWithNoTransferFlag() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         uint256 claimId = bullaClaim.createClaim(
             new CreateClaimParamsBuilder()
                 .withCreditor(creditor)
@@ -94,6 +95,7 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
                 .withPayerReceivesClaimOnPayment(false)
                 .build()
         );
+        vm.stopPrank();
 
         vm.prank(debtor);
         bullaClaim.payClaim{value: 1 ether}(claimId, 1 ether);
@@ -139,7 +141,7 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
 
         _permitCreateClaim(userPK, controller, 1, CreateClaimApprovalType.Approved, true);
 
-        vm.prank(controller);
+        vm.startPrank(controller);
         bullaClaim.createClaimFrom(
             userAddress,
             new CreateClaimParamsBuilder()
@@ -148,6 +150,7 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
                 .withPayerReceivesClaimOnPayment(false)
                 .build()
         );
+        vm.stopPrank();
 
         vm.prank(debtor);
         vm.expectRevert(abi.encodeWithSelector(BullaClaim.NotController.selector, debtor));
@@ -246,7 +249,7 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
 
     
     function testOriginalCreditorAfterPayment() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         uint256 claimId = bullaClaim.createClaim(
             new CreateClaimParamsBuilder()
                 .withCreditor(creditor)
@@ -254,7 +257,8 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
                 .withToken(address(weth))
                 .build()
         );
-        
+        vm.stopPrank();
+
         // Approve and pay claim
         vm.startPrank(debtor);
         weth.approve(address(bullaClaim), 1 ether);

--- a/test/foundry/BullaClaim/PayClaim/PayClaim.t.sol
+++ b/test/foundry/BullaClaim/PayClaim/PayClaim.t.sol
@@ -8,6 +8,7 @@ import "contracts/types/Types.sol";
 import {BullaClaim} from "contracts/BullaClaim.sol";
 import {BullaClaimTestHelper, EIP712Helper} from "test/foundry/BullaClaim/BullaClaimTestHelper.sol";
 import {Deployer} from "script/Deployment.s.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 contract TestPayClaimWithFee is BullaClaimTestHelper {
     address creditor = address(0xA11c3);
@@ -41,15 +42,12 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
     function _newClaim(address creator, bool isNative, uint256 claimAmount) private returns (uint256 claimId) {
         vm.prank(creator);
         claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: claimAmount,
-                token: isNative ? address(0) : address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withClaimAmount(claimAmount)
+                .withToken(isNative ? address(0) : address(weth))
+                .build()
         );
     }
 
@@ -90,15 +88,11 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
     function testPayClaimWithNoTransferFlag() public {
         vm.prank(creditor);
         uint256 claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: false
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withPayerReceivesClaimOnPayment(false)
+                .build()
         );
 
         vm.prank(debtor);
@@ -148,15 +142,11 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
         vm.prank(controller);
         bullaClaim.createClaimFrom(
             userAddress,
-            CreateClaimParams({
-                creditor: userAddress,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: false
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(userAddress)
+                .withDebtor(debtor)
+                .withPayerReceivesClaimOnPayment(false)
+                .build()
         );
 
         vm.prank(debtor);
@@ -258,15 +248,11 @@ contract TestPayClaimWithFee is BullaClaimTestHelper {
     function testOriginalCreditorAfterPayment() public {
         vm.prank(creditor);
         uint256 claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .build()
         );
         
         // Approve and pay claim

--- a/test/foundry/BullaClaim/PayClaim/PayClaimFrom.t.sol
+++ b/test/foundry/BullaClaim/PayClaim/PayClaimFrom.t.sol
@@ -333,14 +333,14 @@ contract TestPayClaimFrom is BullaClaimTestHelper {
     function testPayClaimFromWithNativeToken() public {
         vm.deal(operator, 1 ether);
 
+        CreateClaimParams memory params = new CreateClaimParamsBuilder()
+            .withCreditor(user2)
+            .withDebtor(user)
+            .withPayerReceivesClaimOnPayment(true)
+            .build();
+            
         vm.prank(user2);
-        uint256 claimId = bullaClaim.createClaim(
-            new CreateClaimParamsBuilder()
-                .withCreditor(user2)
-                .withDebtor(user)
-                .withPayerReceivesClaimOnPayment(true)
-                .build()
-        );
+        uint256 claimId = bullaClaim.createClaim(params);
 
         _permitPayClaim({_userPK: userPK, _operator: operator, _approvalDeadline: 0});
 

--- a/test/foundry/BullaClaim/PayClaim/PayClaimFrom.t.sol
+++ b/test/foundry/BullaClaim/PayClaim/PayClaimFrom.t.sol
@@ -8,6 +8,7 @@ import {EIP712Helper} from "test/foundry/BullaClaim/EIP712/Utils.sol";
 import {BullaClaim} from "contracts/BullaClaim.sol";
 import {Deployer} from "script/Deployment.s.sol";
 import {BullaClaimTestHelper} from "test/foundry/BullaClaim/BullaClaimTestHelper.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 /// @notice SPEC:
 /// A function can call this internal function to verify and "spend" `from`'s approval of `operator` to pay a claim under the following circumstances:
@@ -334,15 +335,11 @@ contract TestPayClaimFrom is BullaClaimTestHelper {
 
         vm.prank(user2);
         uint256 claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: user2,
-                debtor: user,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0), // native token
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(user2)
+                .withDebtor(user)
+                .withPayerReceivesClaimOnPayment(true)
+                .build()
         );
 
         _permitPayClaim({_userPK: userPK, _operator: operator, _approvalDeadline: 0});

--- a/test/foundry/BullaClaim/PayClaim/PayClaimWithWeirdTokens.t.sol
+++ b/test/foundry/BullaClaim/PayClaim/PayClaimWithWeirdTokens.t.sol
@@ -94,8 +94,9 @@ contract TestPayClaimWithWeirdTokens is Test {
         for (uint256 i = 0; i < tokens.length; i++) {
             ERC20 token = tokens[i];
 
-            vm.prank(creditor);
+            vm.startPrank(creditor);
             uint256 claimId = _newClaim(address(token), CLAIM_AMOUNT);
+            vm.stopPrank();
 
             uint256 creditorBalanceBefore = token.balanceOf(creditor);
             uint256 debtorBalanceBefore = token.balanceOf(debtor);
@@ -130,8 +131,15 @@ contract TestPayClaimWithWeirdTokens is Test {
         feeToken.mint(debtor, CLAIM_AMOUNT * 2);
         tokenFeeAmount = (CLAIM_AMOUNT * feeToken.FEE_BPS()) / 10000;
 
+        CreateClaimParams memory params = new CreateClaimParamsBuilder()
+            .withCreditor(creditor)
+            .withDebtor(debtor)
+            .withClaimAmount(CLAIM_AMOUNT)
+            .withToken(address(feeToken))
+            .build();
+            
         vm.prank(creditor);
-        uint256 claimId_creditorFee = _newClaim(address(feeToken), CLAIM_AMOUNT);
+        uint256 claimId_creditorFee = bullaClaim.createClaim(params);
 
         creditorBalanceBefore = feeToken.balanceOf(creditor);
         debtorBalanceBefore = feeToken.balanceOf(debtor);
@@ -156,8 +164,9 @@ contract TestPayClaimWithWeirdTokens is Test {
         assertEq(uint256(claim.status), uint256(Status.Paid));
 
         // ensure debtor fee
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         uint256 claimId_debtorFee = _newClaim(address(feeToken), CLAIM_AMOUNT);
+        vm.stopPrank();
 
         creditorBalanceBefore = feeToken.balanceOf(creditor);
         debtorBalanceBefore = feeToken.balanceOf(debtor);

--- a/test/foundry/BullaClaim/PayClaim/PayClaimWithWeirdTokens.t.sol
+++ b/test/foundry/BullaClaim/PayClaim/PayClaimWithWeirdTokens.t.sol
@@ -18,6 +18,7 @@ import {FeeOnTransferToken} from "contracts/mocks/FeeOnTransferToken.sol";
 import {BullaClaim} from "contracts/BullaClaim.sol";
 import {Claim, Status, ClaimBinding, CreateClaimParams, LockState} from "contracts/types/Types.sol";
 import {Deployer} from "script/Deployment.s.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 contract TestPayClaimWithWeirdTokens is Test {
     using Strings for uint256;
@@ -60,15 +61,12 @@ contract TestPayClaimWithWeirdTokens is Test {
 
     function _newClaim(address token, uint256 claimAmount) private returns (uint256 claimId) {
         claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: claimAmount,
-                token: token,
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withClaimAmount(claimAmount)
+                .withToken(token)
+                .build()
         );
     }
 

--- a/test/foundry/BullaClaim/TestInvariants.t.sol
+++ b/test/foundry/BullaClaim/TestInvariants.t.sol
@@ -97,6 +97,14 @@ contract TestInvariants is Test {
         uint256 claimId;
         uint256 fullPaymentAmount;
 
+        CreateClaimParams memory params = new CreateClaimParamsBuilder()
+            .withCreditor(creditor)
+            .withDebtor(debtor)
+            .withClaimAmount(_claimAmount)
+            .withDescription("")
+            .withToken(address(weth))
+            .build();
+
         vm.expectEmit(true, true, true, true);
         emit ClaimCreated(
             bullaClaim.currentClaimId() + 1,
@@ -111,14 +119,7 @@ contract TestInvariants is Test {
         );
 
         vm.prank(creditor);
-        claimId = bullaClaim.createClaim(
-            new CreateClaimParamsBuilder()
-                .withCreditor(creditor)
-                .withDebtor(debtor)
-                .withClaimAmount(_claimAmount)
-                .withToken(address(weth))
-                .build()
-        );
+        claimId = bullaClaim.createClaim(params);
 
         fullPaymentAmount = _claimAmount;
 

--- a/test/foundry/BullaClaim/TestInvariants.t.sol
+++ b/test/foundry/BullaClaim/TestInvariants.t.sol
@@ -10,6 +10,7 @@ import {BullaClaim} from "contracts/BullaClaim.sol";
 import {BullaHelpers} from "contracts/libraries/BullaHelpers.sol";
 import {Deployer} from "script/Deployment.s.sol";
 import {Claim, Status, ClaimBinding, LockState, CreateClaimParams} from "contracts/types/Types.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 enum BullaClaimState {
     NoOwner,
@@ -111,15 +112,12 @@ contract TestInvariants is Test {
 
         vm.prank(creditor);
         claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: _claimAmount,
-                token: address(weth),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withClaimAmount(_claimAmount)
+                .withToken(address(weth))
+                .build()
         );
 
         fullPaymentAmount = _claimAmount;

--- a/test/foundry/BullaClaim/TokenURI.t.sol
+++ b/test/foundry/BullaClaim/TokenURI.t.sol
@@ -6,6 +6,7 @@ import {Claim, Status, ClaimBinding, LockState, CreateClaimParams, ClaimMetadata
 import {BullaClaim} from "contracts/BullaClaim.sol";
 import {ClaimMetadataGenerator} from "contracts/ClaimMetadataGenerator.sol";
 import {Deployer} from "script/Deployment.s.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 contract TestTokenURI is Test {
     BullaClaim public bullaClaim;
@@ -29,15 +30,10 @@ contract TestTokenURI is Test {
 
         vm.prank(creditor);
         uint256 claimId = bullaClaim.createClaimWithMetadata(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            }),
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .build(),
             ClaimMetadata({tokenURI: tokenURI, attachmentURI: "test1234"})
         );
 
@@ -50,15 +46,10 @@ contract TestTokenURI is Test {
 
         vm.prank(creditor);
         uint256 claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .build()
         );
 
         Claim memory claim = bullaClaim.getClaim(claimId);
@@ -75,15 +66,10 @@ contract TestTokenURI is Test {
     function testRevertsIfNoMetadataGenerator() public {
         vm.prank(creditor);
         uint256 claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(0),
-                binding: ClaimBinding.Unbound,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .build()
         );
 
         vm.expectRevert();

--- a/test/foundry/BullaClaim/TokenURI.t.sol
+++ b/test/foundry/BullaClaim/TokenURI.t.sol
@@ -28,7 +28,7 @@ contract TestTokenURI is Test {
     function testTokenURIReturnsSetMetadata() public {
         string memory tokenURI = "tokenURI.com";
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         uint256 claimId = bullaClaim.createClaimWithMetadata(
             new CreateClaimParamsBuilder()
                 .withCreditor(creditor)
@@ -36,6 +36,7 @@ contract TestTokenURI is Test {
                 .build(),
             ClaimMetadata({tokenURI: tokenURI, attachmentURI: "test1234"})
         );
+        vm.stopPrank();
 
         assertEq(bullaClaim.tokenURI(claimId), tokenURI);
     }
@@ -44,13 +45,14 @@ contract TestTokenURI is Test {
         address metadataGenerator = address(new ClaimMetadataGenerator());
         bullaClaim.setClaimMetadataGenerator(metadataGenerator);
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         uint256 claimId = bullaClaim.createClaim(
             new CreateClaimParamsBuilder()
                 .withCreditor(creditor)
                 .withDebtor(debtor)
                 .build()
         );
+        vm.stopPrank();
 
         Claim memory claim = bullaClaim.getClaim(claimId);
 
@@ -64,13 +66,14 @@ contract TestTokenURI is Test {
     }
 
     function testRevertsIfNoMetadataGenerator() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         uint256 claimId = bullaClaim.createClaim(
             new CreateClaimParamsBuilder()
                 .withCreditor(creditor)
                 .withDebtor(debtor)
                 .build()
         );
+        vm.stopPrank();
 
         vm.expectRevert();
         bullaClaim.tokenURI(claimId);

--- a/test/foundry/BullaClaim/UpdateBinding.t.sol
+++ b/test/foundry/BullaClaim/UpdateBinding.t.sol
@@ -54,8 +54,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
     /// @notice SPEC._spendUpdateBindingApproval.S1
     function testDebtorBindsSelfToClaim() public {
         // test case: unbound invoice
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId, Claim memory claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         vm.prank(debtor);
         vm.expectEmit(true, true, true, true);
@@ -68,10 +69,12 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         assertTrue(claim.binding == ClaimBinding.Bound);
 
         // test with operator
-        vm.prank(creditor);
+        vm.startPrank(creditor);
 
         // make a new claim
         (claimId, claim) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
+
         assertTrue(claimId == 2 && claim.binding == ClaimBinding.Unbound);
 
         // permit an operator
@@ -90,8 +93,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
     /// @notice SPEC._spendUpdateBindingApproval.S1
     function testDebtorUpdatesToBindingPending() public {
         // test case: strange, but debtor can update to pending
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId, Claim memory claim) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
 
         vm.prank(debtor);
         vm.expectEmit(true, true, true, true);
@@ -104,10 +108,12 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         assertTrue(claim.binding == ClaimBinding.BindingPending);
 
         // test with operator
-        vm.prank(creditor);
+        vm.startPrank(creditor);
 
         // make a new claim
         (claimId, claim) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
+
         assertTrue(claimId == 2 && claim.binding == ClaimBinding.BindingPending);
 
         // permit an operator
@@ -125,8 +131,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
 
     function testDebtorCannotUnbindIfBound() public {
         // test case: debtor agrees to an invoice, but tries to back out
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         vm.startPrank(debtor);
         vm.expectEmit(true, true, true, true);
@@ -147,8 +154,10 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         assertTrue(bullaClaim.getClaim(claimId).binding == ClaimBinding.Bound);
 
         // test with operator
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
+
         // permit an operator
         _permitUpdateBinding({_userPK: debtorPK, _operator: operator, _approvalCount: type(uint64).max});
 
@@ -166,8 +175,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
 
     function testCreditorCanUpdateToBindingPending() public {
         // test case: creditor wants a debtor to commit to a claim
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         vm.expectEmit(true, true, true, true);
         emit BindingUpdated(claimId, creditor, ClaimBinding.BindingPending);
@@ -179,8 +189,10 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         assertTrue(bullaClaim.getClaim(claimId).binding == ClaimBinding.BindingPending);
 
         // test with an operator
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
+
         // permit an operator
         _permitUpdateBinding({_userPK: creditorPK, _operator: operator, _approvalCount: type(uint64).max});
 
@@ -201,8 +213,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
 
     function testCannotUpdateBindingNotPending(uint8 _claimStatus) public {
         Status claimStatus = Status(_claimStatus % 4);
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
 
         vm.deal(debtor, 1 ether);
         vm.startPrank(debtor);
@@ -233,8 +246,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
 
     function testCreditorCanUpdateToUnbound() public {
         // test case: creditor can "free" a debtor from a claim
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
 
         // debtor accepts
         vm.prank(debtor);
@@ -267,8 +281,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
 
     function testOperatorCanUpdateToUnboundForCreditor() public {
         // test case: creditor can "free" a debtor from a claim
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
 
         _permitUpdateBinding({_userPK: creditorPK, _operator: operator, _approvalCount: type(uint64).max});
 
@@ -304,8 +319,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
     function testCreditorCannotUpdateToBound() public {
         uint256 claimId;
         // test case: a malicous creditor tries to directly bind a debtor after claim creation
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         vm.expectRevert(abi.encodeWithSignature("CannotBindClaim()"));
 
@@ -314,8 +330,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         bullaClaim.updateBinding(claimId, ClaimBinding.Bound);
 
         // try the above, but for a binding pending claim
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId,) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
 
         vm.expectRevert(abi.encodeWithSignature("CannotBindClaim()"));
 
@@ -325,8 +342,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         // also test for operators
         _permitUpdateBinding({_userPK: creditorPK, _operator: operator, _approvalCount: type(uint64).max});
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         vm.expectRevert(abi.encodeWithSignature("CannotBindClaim()"));
 
@@ -335,8 +353,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         bullaClaim.updateBindingFrom(creditor, claimId, ClaimBinding.Bound);
 
         // try the above, but for a binding pending claim
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId,) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
 
         vm.expectRevert(abi.encodeWithSignature("CannotBindClaim()"));
 
@@ -349,8 +368,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
 
         ClaimBinding newBinding = ClaimBinding(_newBinding % 3);
 
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.BindingPending);
+        vm.stopPrank();
 
         vm.expectRevert(BullaClaim.NotCreditorOrDebtor.selector);
 
@@ -363,7 +383,7 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         address controllerAddress = address(0xDEADCAFE);
         _permitCreateClaim(creditorPK, controllerAddress, 1, CreateClaimApprovalType.Approved, false);
 
-        vm.prank(controllerAddress);
+        vm.startPrank(controllerAddress);
         uint256 claimId = bullaClaim.createClaimFrom(
             creditor,
             new CreateClaimParamsBuilder()
@@ -373,6 +393,7 @@ contract TestUpdateBinding is BullaClaimTestHelper {
                 .withBinding(ClaimBinding.BindingPending)
                 .build()
         );
+        vm.stopPrank();
 
         // creditor can't update the binding directly
         vm.prank(creditor);
@@ -392,8 +413,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
 
     /// @notice SPEC._spendUpdateBindingApproval.RES1
     function testUpdateBindingFromDecrementsApprovals() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
         _permitUpdateBinding({_userPK: creditorPK, _operator: operator, _approvalCount: 12});
 
         vm.prank(operator);
@@ -404,8 +426,10 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         assertEq(approval.approvalCount, 11);
 
         // doesn't decrement if approvalCount is uint64.max
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
+
         _permitUpdateBinding({_userPK: creditorPK, _operator: operator, _approvalCount: type(uint64).max});
 
         vm.prank(operator);
@@ -418,8 +442,9 @@ contract TestUpdateBinding is BullaClaimTestHelper {
 
     /// @notice SPEC._spendUpdateBindingApproval.S1
     function testCannotUpdateBindingFromIfUnauthorized() public {
-        vm.prank(creditor);
+        vm.startPrank(creditor);
         (uint256 claimId,) = _newClaim(ClaimBinding.Unbound);
+        vm.stopPrank();
 
         _permitUpdateBinding({_userPK: creditorPK, _operator: operator, _approvalCount: 1});
 

--- a/test/foundry/BullaClaim/UpdateBinding.t.sol
+++ b/test/foundry/BullaClaim/UpdateBinding.t.sol
@@ -9,6 +9,7 @@ import {BullaClaim} from "contracts/BullaClaim.sol";
 import {EIP712Helper} from "test/foundry/BullaClaim/EIP712/Utils.sol";
 import {Deployer} from "script/Deployment.s.sol";
 import {BullaClaimTestHelper} from "test/foundry/BullaClaim/BullaClaimTestHelper.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 /// @notice covers test cases for updateBinding() and updateBindingFrom()
 /// @notice SPEC: updateBinding() TODO
@@ -40,15 +41,12 @@ contract TestUpdateBinding is BullaClaimTestHelper {
 
     function _newClaim(ClaimBinding binding) internal returns (uint256 claimId, Claim memory claim) {
         claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: binding,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .withBinding(binding)
+                .build()
         );
         claim = bullaClaim.getClaim(claimId);
     }
@@ -368,15 +366,12 @@ contract TestUpdateBinding is BullaClaimTestHelper {
         vm.prank(controllerAddress);
         uint256 claimId = bullaClaim.createClaimFrom(
             creditor,
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                description: "",
-                claimAmount: 1 ether,
-                token: address(weth),
-                binding: ClaimBinding.BindingPending,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withToken(address(weth))
+                .withBinding(ClaimBinding.BindingPending)
+                .build()
         );
 
         // creditor can't update the binding directly

--- a/test/foundry/BullaFrendLend/BullaFrendLend.t.sol
+++ b/test/foundry/BullaFrendLend/BullaFrendLend.t.sol
@@ -317,7 +317,7 @@ contract TestBullaFrendLend is Test {
         vm.prank(creditor);
         bullaFrendLend.rejectLoanOffer(loanId);
 
-        (uint24 interestBPS, uint40 termLength, uint128 loanAmount, address offerCreditor, ,, ) = bullaFrendLend.loanOffers(loanId);
+        (, , , address offerCreditor, ,, ) = bullaFrendLend.loanOffers(loanId);
         assertEq(offerCreditor, address(0), "Offer should be deleted after rejection");
     }
 
@@ -393,7 +393,7 @@ contract TestBullaFrendLend is Test {
         bullaFrendLend.payLoan(claimId, firstPaymentAmount);
         
         // Check loan state after first payment
-        (uint256 remainingPrincipal1, uint256 currentInterest1) = bullaFrendLend.getTotalAmountDue(claimId);
+        (, uint256 currentInterest1) = bullaFrendLend.getTotalAmountDue(claimId);
         Loan memory loanAfterFirstPayment = bullaFrendLend.getLoan(claimId);
         
         assertEq(loanAfterFirstPayment.paidAmount, firstPaymentAmount - currentInterest1, "Paid amount after first payment incorrect");
@@ -408,7 +408,7 @@ contract TestBullaFrendLend is Test {
         bullaFrendLend.payLoan(claimId, secondPaymentAmount);
         
         // Check loan state after second payment
-        (uint256 remainingPrincipal2, uint256 currentInterest2) = bullaFrendLend.getTotalAmountDue(claimId);
+        (, uint256 currentInterest2) = bullaFrendLend.getTotalAmountDue(claimId);
         Loan memory loanAfterSecondPayment = bullaFrendLend.getLoan(claimId);
         
         assertEq(loanAfterSecondPayment.paidAmount, loanAfterFirstPayment.paidAmount + (secondPaymentAmount - currentInterest2), 
@@ -591,7 +591,7 @@ contract TestBullaFrendLend is Test {
         assertTrue(loan.status == Status.Paid, "Loan should be fully paid");
         assertEq(loan.paidAmount, loan.claimAmount, "Paid amount should equal loan amount");
         
-        (uint256 remainingPrincipal, uint256 currentInterest) = bullaFrendLend.getTotalAmountDue(claimId);
+        (, uint256 currentInterest) = bullaFrendLend.getTotalAmountDue(claimId);
         
         // Calculate protocol fee from interest
         uint256 protocolFee = bullaFrendLend.calculateProtocolFee(currentInterest);

--- a/test/foundry/BullaInvoice/BullaInvoice.t.sol
+++ b/test/foundry/BullaInvoice/BullaInvoice.t.sol
@@ -11,6 +11,7 @@ import {BullaClaim} from "contracts/BullaClaim.sol";
 import {BullaInvoice, CreateInvoiceParams, Invoice, InvalidDueBy, CreditorCannotBeDebtor, InvalidDeliveryDate, NotOriginalCreditor, PurchaseOrderAlreadyDelivered, InvoiceNotPending, PurchaseOrderState, InvoiceDetails, NotPurchaseOrder} from "contracts/BullaInvoice.sol";
 import {Deployer} from "script/Deployment.s.sol";
 import {CreateInvoiceParamsBuilder} from "test/foundry/BullaInvoice/CreateInvoiceParamsBuilder.sol";
+import {CreateClaimParamsBuilder} from "test/foundry/BullaClaim/CreateClaimParamsBuilder.sol";
 
 contract TestBullaInvoice is Test {
     WETH public weth;
@@ -995,15 +996,14 @@ contract TestBullaInvoice is Test {
         // Create a claim directly via BullaClaim
         vm.prank(creditor);
         uint256 claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                claimAmount: 1 ether,
-                description: "Direct Claim",
-                token: address(0),
-                binding: ClaimBinding.BindingPending,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withClaimAmount(1 ether)
+                .withDescription("Direct Claim")
+                .withToken(address(0))
+                .withBinding(ClaimBinding.BindingPending)
+                .build()
         );
 
         // Try to pay via BullaInvoice
@@ -1017,15 +1017,14 @@ contract TestBullaInvoice is Test {
         // Create a claim directly via BullaClaim
         vm.prank(creditor);
         uint256 claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                claimAmount: 1 ether,
-                description: "Direct Claim",
-                token: address(0),
-                binding: ClaimBinding.BindingPending,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withClaimAmount(1 ether)
+                .withDescription("Direct Claim")
+                .withToken(address(0))
+                .withBinding(ClaimBinding.BindingPending)
+                .build()
         );
 
         // Setup binding permit
@@ -1052,15 +1051,14 @@ contract TestBullaInvoice is Test {
         // Create a claim directly via BullaClaim
         vm.prank(creditor);
         uint256 claimId = bullaClaim.createClaim(
-            CreateClaimParams({
-                creditor: creditor,
-                debtor: debtor,
-                claimAmount: 1 ether,
-                description: "Direct Claim",
-                token: address(0),
-                binding: ClaimBinding.BindingPending,
-                payerReceivesClaimOnPayment: true
-            })
+            new CreateClaimParamsBuilder()
+                .withCreditor(creditor)
+                .withDebtor(debtor)
+                .withClaimAmount(1 ether)
+                .withDescription("Direct Claim")
+                .withToken(address(0))
+                .withBinding(ClaimBinding.BindingPending)
+                .build()
         );
 
         // Try to cancel via BullaInvoice

--- a/test/foundry/BullaInvoice/BullaInvoice.t.sol
+++ b/test/foundry/BullaInvoice/BullaInvoice.t.sol
@@ -994,17 +994,17 @@ contract TestBullaInvoice is Test {
     // Test trying to pay a claim that was not created by BullaInvoice
     function testPayDirectClaim() public {
         // Create a claim directly via BullaClaim
+        CreateClaimParams memory params = new CreateClaimParamsBuilder()
+            .withCreditor(creditor)
+            .withDebtor(debtor)
+            .withClaimAmount(1 ether)
+            .withDescription("Direct Claim")
+            .withToken(address(0))
+            .withBinding(ClaimBinding.BindingPending)
+            .build();
+            
         vm.prank(creditor);
-        uint256 claimId = bullaClaim.createClaim(
-            new CreateClaimParamsBuilder()
-                .withCreditor(creditor)
-                .withDebtor(debtor)
-                .withClaimAmount(1 ether)
-                .withDescription("Direct Claim")
-                .withToken(address(0))
-                .withBinding(ClaimBinding.BindingPending)
-                .build()
-        );
+        uint256 claimId = bullaClaim.createClaim(params);
 
         // Try to pay via BullaInvoice
         vm.prank(debtor);
@@ -1015,17 +1015,14 @@ contract TestBullaInvoice is Test {
     // Test trying to update binding of a claim that was not created by BullaInvoice
     function testUpdateBindingDirectClaim() public {
         // Create a claim directly via BullaClaim
+        CreateClaimParams memory params = new CreateClaimParamsBuilder()
+            .withCreditor(creditor)
+            .withDebtor(debtor)
+            .withBinding(ClaimBinding.BindingPending)
+            .build();
+            
         vm.prank(creditor);
-        uint256 claimId = bullaClaim.createClaim(
-            new CreateClaimParamsBuilder()
-                .withCreditor(creditor)
-                .withDebtor(debtor)
-                .withClaimAmount(1 ether)
-                .withDescription("Direct Claim")
-                .withToken(address(0))
-                .withBinding(ClaimBinding.BindingPending)
-                .build()
-        );
+        uint256 claimId = bullaClaim.createClaim(params);
 
         // Setup binding permit
         bullaClaim.permitUpdateBinding({
@@ -1049,17 +1046,15 @@ contract TestBullaInvoice is Test {
     // Test trying to cancel a claim that was not created by BullaInvoice
     function testCancelDirectClaim() public {
         // Create a claim directly via BullaClaim
+        CreateClaimParams memory params = new CreateClaimParamsBuilder()
+            .withCreditor(creditor)
+            .withDebtor(debtor)
+            .withClaimAmount(1 ether)
+            .withBinding(ClaimBinding.BindingPending)
+            .build();
+            
         vm.prank(creditor);
-        uint256 claimId = bullaClaim.createClaim(
-            new CreateClaimParamsBuilder()
-                .withCreditor(creditor)
-                .withDebtor(debtor)
-                .withClaimAmount(1 ether)
-                .withDescription("Direct Claim")
-                .withToken(address(0))
-                .withBinding(ClaimBinding.BindingPending)
-                .build()
-        );
+        uint256 claimId = bullaClaim.createClaim(params);
 
         // Try to cancel via BullaInvoice
         vm.prank(creditor);


### PR DESCRIPTION
Thought this would be quite and easy but turns out the pranking and revert expectations makes things a bit annoying.

Builders help to reduce the amount of changes needed when changing fields for a type.

If they are used all over the place, it makes things more maintainable.

Unfortunately took a bit more time to integrate today, but should be smooth sailing for later.

Also, I targeted your current branch to avoid merge conflicts for both of us.