### PR TITLE
fix: validate deposit covers accrued interest in acceptPurchaseOrder

### DIFF
--- a/src/BullaInvoice.sol
+++ b/src/BullaInvoice.sol
@@ -19,6 +19,7 @@ error InvoiceNotPending();
 error NotPurchaseOrder();
 error PayingZero();
 error InvalidDepositAmount();
+error InsufficientDepositAmount();
 error NotAuthorizedForBinding();
 error InvalidMsgValue();
 error InvalidProtocolFee();
@@ -275,6 +276,20 @@ contract BullaInvoice is BullaClaimControllerBase, ERC165, Ownable, IBullaInvoic
             invoiceDetails.interestComputationState
         );
 
+        _payInvoiceUnsafe(claimId, paymentAmount, claim, invoiceDetails, interestComputationState);
+    }
+
+    /**
+     * @notice Internal payment logic that skips re-fetching claim data and recomputing interest
+     * @dev Callers must ensure claim, invoiceDetails, and interestComputationState are up-to-date
+     */
+    function _payInvoiceUnsafe(
+        uint256 claimId,
+        uint256 paymentAmount,
+        Claim memory claim,
+        InvoiceDetails memory invoiceDetails,
+        InterestComputationState memory interestComputationState
+    ) private {
         uint256 grossInterestBeingPaid = Math.min(paymentAmount, interestComputationState.accruedInterest);
         uint256 principalBeingPaid =
             Math.min(paymentAmount - grossInterestBeingPaid, claim.claimAmount - claim.paidAmount);
@@ -449,12 +464,6 @@ contract BullaInvoice is BullaClaimControllerBase, ERC165, Ownable, IBullaInvoic
             revert NotAuthorizedForBinding();
         }
 
-        // Validate that the payment amount doesn't exceed what's left to pay on the claim
-        uint256 amountLeftToPay = claim.claimAmount - claim.paidAmount;
-        if (depositAmount > amountLeftToPay) {
-            revert InvalidDepositAmount();
-        }
-
         // Calculate and store interest computation state
         InterestComputationState memory interestComputationState = CompoundInterestLib.computeInterest(
             claim.claimAmount - claim.paidAmount,
@@ -467,7 +476,20 @@ contract BullaInvoice is BullaClaimControllerBase, ERC165, Ownable, IBullaInvoic
             _invoiceDetailsByClaimId[claimId].interestComputationState = interestComputationState;
         }
 
-        bool isBound = false;
+        // Validate that the payment amount doesn't exceed what's left to pay (principal + accrued interest)
+        uint256 amountLeftToPay = claim.claimAmount + interestComputationState.accruedInterest - claim.paidAmount;
+
+        if (depositAmount > amountLeftToPay) {
+            revert InvalidDepositAmount();
+        }
+
+        // Check that the deposit amount covers the total needed (principal deposit + accrued interest)
+        uint256 depositAmountNeeded =
+            _getTotalAmountNeededForPurchaseOrderDepositUnsafe(claim, invoiceDetails, interestComputationState);
+
+        if (depositAmountNeeded > depositAmount) {
+            revert InsufficientDepositAmount();
+        }
 
         // Pay the deposit amount if any
         if (depositAmount > 0) {
@@ -484,38 +506,18 @@ contract BullaInvoice is BullaClaimControllerBase, ERC165, Ownable, IBullaInvoic
                 }
             }
 
-            // Use payInvoice to handle payment (interest already calculated and stored above)
-            payInvoice(claimId, depositAmount);
-
-            // After payment, get updated claim data and use unsafe version
-            Claim memory updatedClaim = _bullaClaim.getClaim(claimId);
-            InvoiceDetails memory updatedInvoiceDetails = _invoiceDetailsByClaimId[claimId];
-
-            uint256 totalAmountNeeded = _getTotalAmountNeededForPurchaseOrderDepositUnsafe(
-                updatedClaim, updatedInvoiceDetails, updatedInvoiceDetails.interestComputationState
-            );
-
-            if (totalAmountNeeded == 0) {
-                _bullaClaim.updateBindingFrom(msg.sender, claimId, ClaimBinding.Bound);
-                isBound = true;
-            }
+            // Use _payInvoiceUnsafe to avoid re-fetching claim and recomputing interest
+            _payInvoiceUnsafe(claimId, depositAmount, claim, invoiceDetails, interestComputationState);
         } else {
             // If no payment needed, msg.value should be 0
             if (msg.value != 0) {
                 revert InvalidMsgValue();
             }
-
-            // Use the already calculated interest computation state
-            uint256 totalAmountNeeded =
-                _getTotalAmountNeededForPurchaseOrderDepositUnsafe(claim, invoiceDetails, interestComputationState);
-
-            if (totalAmountNeeded == 0) {
-                _bullaClaim.updateBindingFrom(msg.sender, claimId, ClaimBinding.Bound);
-                isBound = true;
-            }
         }
 
-        emit PurchaseOrderAccepted(claimId, msg.sender, depositAmount, isBound);
+        _bullaClaim.updateBindingFrom(msg.sender, claimId, ClaimBinding.Bound);
+
+        emit PurchaseOrderAccepted(claimId, msg.sender, depositAmount, true);
     }
 
     /**

--- a/test/foundry/BullaInvoice/BullaInvoice.t.sol
+++ b/test/foundry/BullaInvoice/BullaInvoice.t.sol
@@ -21,6 +21,7 @@ import {
     InvoiceDetails,
     NotPurchaseOrder,
     InvalidDepositAmount,
+    InsufficientDepositAmount,
     InvalidMsgValue,
     NotAuthorizedForBinding
 } from "contracts/BullaInvoice.sol";
@@ -1963,43 +1964,10 @@ contract TestBullaInvoice is Test {
         vm.prank(creditor);
         uint256 invoiceId = bullaInvoice.createInvoice(params);
 
-        // Accept purchase order by paying partial deposit
+        // Accepting with a partial deposit should revert
+        vm.expectRevert(abi.encodeWithSelector(InsufficientDepositAmount.selector));
         vm.prank(debtor);
         bullaInvoice.acceptPurchaseOrder{value: partialDepositAmount}(invoiceId, partialDepositAmount);
-
-        // Verify purchase order acceptance - should NOT be bound with partial deposit
-        Invoice memory invoice = bullaInvoice.getInvoice(invoiceId);
-        assertEq(
-            uint8(invoice.binding),
-            uint8(ClaimBinding.BindingPending),
-            "Invoice should remain BindingPending with partial deposit"
-        );
-        assertEq(invoice.paidAmount, partialDepositAmount, "Paid amount should equal partial deposit");
-
-        // Verify remaining deposit
-        uint256 remainingDeposit = bullaInvoice.getTotalAmountNeededForPurchaseOrderDeposit(invoiceId);
-        assertEq(
-            remainingDeposit,
-            totalDepositAmount - partialDepositAmount,
-            "Remaining deposit should be calculated correctly"
-        );
-        assertTrue(remainingDeposit > 0, "Should still have remaining deposit amount");
-
-        // Now pay the remaining deposit to complete the binding
-        uint256 finalDepositAmount = remainingDeposit;
-        vm.prank(debtor);
-        bullaInvoice.acceptPurchaseOrder{value: finalDepositAmount}(invoiceId, finalDepositAmount);
-
-        // Verify purchase order is now bound after full deposit
-        invoice = bullaInvoice.getInvoice(invoiceId);
-        assertEq(
-            uint8(invoice.binding), uint8(ClaimBinding.Bound), "Invoice should be Bound after full deposit is paid"
-        );
-        assertEq(invoice.paidAmount, totalDepositAmount, "Total paid amount should equal full deposit");
-
-        // Verify no remaining deposit
-        remainingDeposit = bullaInvoice.getTotalAmountNeededForPurchaseOrderDeposit(invoiceId);
-        assertEq(remainingDeposit, 0, "No remaining deposit should be left");
     }
 
     function testAcceptPurchaseOrder_ZeroDeposit() public {
@@ -2480,30 +2448,19 @@ contract TestBullaInvoice is Test {
         // Check the amounts excluding accrued interest
         uint256 remainingPrincipalDepositExcludingInterest = depositAmount - invoiceBefore.paidAmount;
 
-        // Attempt to accept purchase order by paying only the principal deposit amount (insufficient)
+        // Attempting to accept with only the principal deposit (no interest) should revert
+        vm.expectRevert(abi.encodeWithSelector(InsufficientDepositAmount.selector));
         vm.prank(debtor);
         bullaInvoice.acceptPurchaseOrder{value: remainingPrincipalDepositExcludingInterest}(
             invoiceId, remainingPrincipalDepositExcludingInterest
         );
 
-        // Verify that the binding was NOT updated to Bound because payment was insufficient
-        Invoice memory invoiceAfter = bullaInvoice.getInvoice(invoiceId);
-        assertEq(
-            uint8(invoiceAfter.binding),
-            uint8(ClaimBinding.BindingPending),
-            "Invoice should remain BindingPending because payment was insufficient"
-        );
+        // Now pay the full amount needed (deposit + accrued interest) to complete the deposit
+        uint256 totalAmountNeeded = bullaInvoice.getTotalAmountNeededForPurchaseOrderDeposit(invoiceId);
+        assertTrue(totalAmountNeeded > depositAmount, "Total amount needed should exceed deposit due to interest");
 
-        // Verify partial payment was made (some interest + partial principal)
-        assertTrue(invoiceAfter.paidAmount > 0, "Some payment should have been made");
-
-        // Verify there's still an amount needed to complete the deposit
-        uint256 remainingAmountNeeded = bullaInvoice.getTotalAmountNeededForPurchaseOrderDeposit(invoiceId);
-        assertTrue(remainingAmountNeeded > 0, "There should still be an amount needed to complete the deposit");
-
-        // Now pay the remaining amount needed to complete the deposit
         vm.prank(debtor);
-        bullaInvoice.acceptPurchaseOrder{value: remainingAmountNeeded}(invoiceId, remainingAmountNeeded);
+        bullaInvoice.acceptPurchaseOrder{value: totalAmountNeeded}(invoiceId, totalAmountNeeded);
 
         // Verify that the binding is updated to Bound
         Invoice memory invoiceFinal = bullaInvoice.getInvoice(invoiceId);
@@ -2900,5 +2857,131 @@ contract TestBullaInvoice is Test {
         // Accept purchase order by paying full deposit
         vm.prank(debtor);
         bullaInvoice.acceptPurchaseOrder{value: depositAmount}(invoiceId, depositAmount);
+    }
+
+    function testAcceptPurchaseOrder_RevertsWhenDepositInsufficientDueToAccruedInterest() public {
+        // Setup permissions (binding allowed so updateBindingFrom can work if it gets that far)
+        bullaClaim.approvalRegistry().permitCreateClaim({
+            user: creditor,
+            controller: address(bullaInvoice),
+            approvalType: CreateClaimApprovalType.Approved,
+            approvalCount: 1,
+            isBindingAllowed: true,
+            signature: sigHelper.signCreateClaimPermit({
+                pk: creditorPK,
+                user: creditor,
+                controller: address(bullaInvoice),
+                approvalType: CreateClaimApprovalType.Approved,
+                approvalCount: 1,
+                isBindingAllowed: true
+            })
+        });
+
+        uint256 depositAmount = 0.5 ether;
+
+        // Create a purchase order with a late fee: 10% APR, daily compounding (365 periods/year)
+        CreateInvoiceParams memory params = new CreateInvoiceParamsBuilder().withDebtor(debtor).withCreditor(creditor)
+            .withClaimAmount(1 ether).withDueBy(block.timestamp + 30 days).withDeliveryDate(block.timestamp + 60 days)
+            .withDepositAmount(depositAmount).withLateFeeConfig(
+            InterestConfig({interestRateBps: 1000, numberOfPeriodsPerYear: 365})
+        ).build();
+
+        vm.prank(creditor);
+        uint256 invoiceId = bullaInvoice.createInvoice(params);
+
+        // Warp to 7 days past the due date — interest has been accruing
+        vm.warp(block.timestamp + 37 days);
+
+        // Accepting with exactly the deposit amount should revert because
+        // accrued interest means the total amount needed exceeds the deposit
+        vm.expectRevert(abi.encodeWithSelector(InsufficientDepositAmount.selector));
+        vm.prank(debtor);
+        bullaInvoice.acceptPurchaseOrder{value: depositAmount}(invoiceId, depositAmount);
+    }
+
+    function testAcceptPurchaseOrder_CanPayPrincipalPlusOneWeiWhenInterestAccrued() public {
+        // Setup permissions
+        bullaClaim.approvalRegistry().permitCreateClaim({
+            user: creditor,
+            controller: address(bullaInvoice),
+            approvalType: CreateClaimApprovalType.Approved,
+            approvalCount: 1,
+            isBindingAllowed: true,
+            signature: sigHelper.signCreateClaimPermit({
+                pk: creditorPK,
+                user: creditor,
+                controller: address(bullaInvoice),
+                approvalType: CreateClaimApprovalType.Approved,
+                approvalCount: 1,
+                isBindingAllowed: true
+            })
+        });
+
+        // Create a PO with deposit < claimAmount, with late fees
+        uint256 claimAmount = 1 ether;
+        uint256 depositAmount = 0.5 ether;
+        CreateInvoiceParams memory params = new CreateInvoiceParamsBuilder().withDebtor(debtor).withCreditor(creditor)
+            .withClaimAmount(claimAmount).withDueBy(block.timestamp + 30 days).withDeliveryDate(block.timestamp + 60 days)
+            .withDepositAmount(depositAmount).withLateFeeConfig(
+            InterestConfig({interestRateBps: 1000, numberOfPeriodsPerYear: 365})
+        ).build();
+
+        vm.prank(creditor);
+        uint256 invoiceId = bullaInvoice.createInvoice(params);
+
+        // Warp past due date so interest accrues
+        vm.warp(block.timestamp + 37 days);
+
+        // Verify interest has accrued
+        Invoice memory invoice = bullaInvoice.getInvoice(invoiceId);
+        assertTrue(invoice.interestComputationState.accruedInterest > 0, "Interest should have accrued");
+
+        // Paying remaining principal (1 ether) + 1 wei should be valid since interest > 0
+        // means the total owed exceeds the principal. Before the fix, this would revert
+        // with InvalidDepositAmount because amountLeftToPay didn't include interest.
+        uint256 payAmount = claimAmount + 1 wei;
+        vm.prank(debtor);
+        bullaInvoice.acceptPurchaseOrder{value: payAmount}(invoiceId, payAmount);
+    }
+
+    function testAcceptPurchaseOrder_ZeroDepositAfterPayInvoiceCoversDeposit() public {
+        // Setup permissions
+        bullaClaim.approvalRegistry().permitCreateClaim({
+            user: creditor,
+            controller: address(bullaInvoice),
+            approvalType: CreateClaimApprovalType.Approved,
+            approvalCount: 1,
+            isBindingAllowed: true,
+            signature: sigHelper.signCreateClaimPermit({
+                pk: creditorPK,
+                user: creditor,
+                controller: address(bullaInvoice),
+                approvalType: CreateClaimApprovalType.Approved,
+                approvalCount: 1,
+                isBindingAllowed: true
+            })
+        });
+
+        // Create a PO: 1 ETH claim with 0.5 ETH deposit required
+        CreateInvoiceParams memory params = new CreateInvoiceParamsBuilder().withDebtor(debtor).withCreditor(creditor)
+            .withClaimAmount(1 ether).withDeliveryDate(block.timestamp + 60 days).withDepositAmount(0.5 ether).build();
+
+        vm.prank(creditor);
+        uint256 invoiceId = bullaInvoice.createInvoice(params);
+
+        // Debtor pays 0.6 ETH via payInvoice (more than the 0.5 ETH deposit)
+        vm.prank(debtor);
+        bullaInvoice.payInvoice{value: 0.6 ether}(invoiceId, 0.6 ether);
+
+        Invoice memory invoice = bullaInvoice.getInvoice(invoiceId);
+        assertEq(invoice.paidAmount, 0.6 ether, "Paid amount should be 0.6 ETH");
+
+        // Accept PO with 0 deposit — deposit already covered by prior payment
+        vm.prank(debtor);
+        bullaInvoice.acceptPurchaseOrder(invoiceId, 0);
+
+        // Verify the PO is bound
+        invoice = bullaInvoice.getInvoice(invoiceId);
+        assertEq(uint8(invoice.binding), uint8(ClaimBinding.Bound), "PO should be bound");
     }
 }


### PR DESCRIPTION
## Summary
- **InsufficientDepositAmount error**: `acceptPurchaseOrder` now reverts if the deposit amount doesn't cover the required deposit + accrued interest (prevents accepting with an amount that would leave the deposit underfunded)
- **Interest-aware InvalidDepositAmount check**: moved the overpayment guard after interest computation so paying more than the remaining principal is valid when interest has accrued
- **_payInvoiceUnsafe refactor**: extracted private payment function to avoid redundant `getClaim`, `_checkController`, and `computeInterest` calls when invoked from `acceptPurchaseOrder`
- **Upfront deposit check**: deposit requirement is validated once before payment instead of re-checking post-payment

## Test plan
- [x] `testAcceptPurchaseOrder_RevertsWhenDepositInsufficientDueToAccruedInterest` — reverts when deposit doesn't cover accrued interest
- [x] `testAcceptPurchaseOrder_PartialDeposit` — reverts with InsufficientDepositAmount for partial deposits
- [x] `testAcceptPurchaseOrder_InsufficientPayment_WithAccruedInterest` — reverts when paying only principal without interest, succeeds when paying full amount needed
- [x] `testAcceptPurchaseOrder_CanPayPrincipalPlusOneWeiWhenInterestAccrued` — paying > remaining principal is valid when interest exists
- [x] `testAcceptPurchaseOrder_ZeroDepositAfterPayInvoiceCoversDeposit` — can accept with 0 deposit after payInvoice already covered the deposit
- [x] All 70 BullaInvoice tests pass
- [x] Full suite: 628 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)